### PR TITLE
Stairway TDR support

### DIFF
--- a/src/main/java/bio/terra/stairway/FlightContext.java
+++ b/src/main/java/bio/terra/stairway/FlightContext.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  * It is what is held in the database for the flight and it is passed into the steps
  */
 public class FlightContext {
+    private Stairway stairway; // the stairway instance running this flight
     private String flightId; // unique id for the flight
     private String flightClassName; // class name of the flight; sufficient for recreating the flight object
     private FlightMap inputParameters; // allows for reconstructing the flight; set unmodifiable
@@ -82,6 +83,14 @@ public class FlightContext {
 
     public void setResult(StepResult result) {
         this.result = result;
+    }
+
+    public Stairway getStairway() {
+        return stairway;
+    }
+
+    public void setStairway(Stairway stairway) {
+        this.stairway = stairway;
     }
 
     /**

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -157,6 +157,7 @@ public class Stairway {
         Flight flight = makeFlight(flightClass, inputParameters);
 
         flight.context().setFlightId(flightId);
+        flight.context().setStairway(this);
         flightDao.submit(flight.context());
         launchFlight(flight);
     }
@@ -271,6 +272,7 @@ public class Stairway {
         for (FlightContext flightContext : flightList) {
             Flight flight = makeFlightFromName(flightContext.getFlightClassName(), flightContext.getInputParameters());
             flightContext.nextStepIndex();
+            flightContext.setStairway(this);
             flight.setFlightContext(flightContext);
             launchFlight(flight);
         }

--- a/src/main/resources/stairway/db/changelog.xml
+++ b/src/main/resources/stairway/db/changelog.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-    <include file="changesets/20200211_base.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20190118_base.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20190801_subjectid.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20191110_fix_exceptions.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20200211_library.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/stairway/db/changesets/20190118_base.yaml
+++ b/src/main/resources/stairway/db/changesets/20190118_base.yaml
@@ -23,6 +23,9 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  name: input_parameters
+                  type: text
+              - column:
                   name: completed_time
                   type: timestamp
               - column:
@@ -33,8 +36,8 @@ databaseChangeLog:
                   type: text
                   remarks: contains FlightStatus enum values
               - column:
-                  name: serialized_exception
-                  remarks: some serialized form of the exception
+                  name: exception
+                  remarks: contains JSON-serialized Exception
                   type: text
 
         - createTable:
@@ -71,9 +74,9 @@ databaseChangeLog:
                   type: boolean
                   remarks: null = not done; true = success; false = failure
               - column:
-                  name: serialized_exception
+                  name: exception
                   type: text
-                  remarks: some serialized form of the exception
+                  remarks: contains JSON-serialized Exception
               - column:
                   name: status
                   type: text
@@ -82,27 +85,3 @@ databaseChangeLog:
             tableName: flightlog
             columnNames: flightid, log_time
             constraintName: pk_flightlog
-
-        - createTable:
-            tableName: flightinput
-            columns:
-              - column:
-                  name: flightid
-                  type: varchar(36)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: key
-                  type: text
-                  constraints:
-                    nullable: false
-              - column:
-                  name: value
-                  type: text
-                  remarks: json with type information
-                  constraints:
-                    nullable: false
-        - addPrimaryKey:
-            tableName: flightinput
-            columnNames: flightid, key
-            constraintName: pk_flightinput

--- a/src/main/resources/stairway/db/changesets/20190801_subjectid.yaml
+++ b/src/main/resources/stairway/db/changesets/20190801_subjectid.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_subject
+      author: ah
+      changes:
+        - addColumn:
+            tableName: flight
+            columns:
+              - column:
+                  name: owner_id
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: owner_email
+                  type: text
+                  constraints:
+                    nullable: false

--- a/src/main/resources/stairway/db/changesets/20191110_fix_exceptions.yaml
+++ b/src/main/resources/stairway/db/changesets/20191110_fix_exceptions.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: remove_exception
+      author: dd
+      changes:
+        - dropColumn:
+            tableName: flight
+            columns:
+              - column:
+                  name: exception
+                  type: text
+        - addColumn:
+            tableName: flight
+            columns:
+              - column:
+                  name: serialized_exception
+                  type: text
+        - dropColumn:
+            tableName: flightlog
+            columns:
+              - column:
+                  name: exception
+                  type: text
+        - addColumn:
+            tableName: flightlog
+            columns:
+              - column:
+                  name: serialized_exception
+                  type: text
+

--- a/src/main/resources/stairway/db/changesets/20200211_library.yaml
+++ b/src/main/resources/stairway/db/changesets/20200211_library.yaml
@@ -1,0 +1,38 @@
+databaseChangeLog:
+  - changeSet:
+      id: stairwaybase
+      author: dd
+      changes:
+        - dropColumn:
+            tableName: flight
+            columns:
+              - column:
+                  name: owner_id
+              - column:
+                  name: owner_email
+              - column:
+                  name: input_parameters
+
+        - createTable:
+            tableName: flightinput
+            columns:
+              - column:
+                  name: flightid
+                  type: varchar(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: key
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: value
+                  type: text
+                  remarks: json with type information
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: flightinput
+            columnNames: flightid, key
+            constraintName: pk_flightinput


### PR DESCRIPTION
This is the last piece of work to bring the Stairway library to parity with the Terra Data Repo library, but with no TDR-specifics. It includes:
- providing the Stairway instance in the FlightContext so flights can launch other flights (used in bulk load)
- restoring the TDR liquibase changesets, so when TDR starts using the Stairway library, it will be able to migrate its databases.
