### PR TITLE
Remove the in-memory map of Futures of active flights

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'bio.terra'
-version '0.0.1-SNAPSHOT'
+version '0.0.3-SNAPSHOT'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/bio/terra/stairway/FlightState.java
+++ b/src/main/java/bio/terra/stairway/FlightState.java
@@ -80,4 +80,7 @@ public class FlightState {
         this.exception = exception;
     }
 
+    public boolean isActive() {
+        return (flightStatus == FlightStatus.RUNNING);
+    }
 }

--- a/src/test/java/bio/terra/stairway/RecoveryTest.java
+++ b/src/test/java/bio/terra/stairway/RecoveryTest.java
@@ -88,7 +88,7 @@ public class RecoveryTest {
         stairway2.initialize(dataSource, false, false);
 
         // Wait for recovery to complete
-        stairway2.waitForFlight(flightId);
+        stairway2.waitForFlight(flightId, null, null);
         FlightState result = stairway2.getFlightState(flightId);
         assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.SUCCESS)));
         assertTrue(result.getResultMap().isPresent());
@@ -126,7 +126,7 @@ public class RecoveryTest {
         stairway2.initialize(dataSource, false, false);
 
         // Wait for recovery to complete
-        stairway2.waitForFlight(flightId);
+        stairway2.waitForFlight(flightId, null, null);
         FlightState result = stairway2.getFlightState(flightId);
         assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.ERROR)));
         assertTrue(result.getException().isPresent());

--- a/src/test/java/bio/terra/stairway/RetryTest.java
+++ b/src/test/java/bio/terra/stairway/RetryTest.java
@@ -35,8 +35,7 @@ public class RetryTest {
 
         String flightId = "successTest";
         stairway.submit(flightId, TestFlightRetry.class, inputParameters);
-        stairway.waitForFlight(flightId);
-        FlightState result = stairway.getFlightState(flightId);
+        FlightState result = stairway.waitForFlight(flightId, null, null);
         assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.SUCCESS)));
         assertFalse(result.getException().isPresent());
     }
@@ -58,8 +57,7 @@ public class RetryTest {
         LocalDateTime startTime = LocalDateTime.now();
         String flightId = "failureTest";
         stairway.submit(flightId, TestFlightRetry.class, inputParameters);
-        stairway.waitForFlight(flightId);
-        FlightState result = stairway.getFlightState(flightId);
+        FlightState result = stairway.waitForFlight(flightId, 1, null);
         LocalDateTime endTime = LocalDateTime.now();
 
         LocalDateTime startRange = startTime.plus(Duration.ofSeconds(maxCount * intervalSeconds));
@@ -81,8 +79,7 @@ public class RetryTest {
 
         String flightId = "exponentialTest";
         stairway.submit(flightId, TestFlightRetry.class, inputParameters);
-        stairway.waitForFlight(flightId);
-        FlightState result = stairway.getFlightState(flightId);
+        FlightState result = stairway.waitForFlight(flightId, null, null);
         assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.SUCCESS)));
         assertFalse(result.getException().isPresent());
     }
@@ -101,8 +98,7 @@ public class RetryTest {
         String flightId = "expOpTimeTest";
         stairway.submit(flightId, TestFlightRetry.class, inputParameters);
 
-        stairway.waitForFlight(flightId);
-        FlightState result = stairway.getFlightState(flightId);
+        FlightState result = stairway.waitForFlight(flightId, null, null);
         assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.ERROR)));
         assertTrue(result.getException().isPresent());
     }
@@ -122,8 +118,7 @@ public class RetryTest {
         LocalDateTime startTime = LocalDateTime.now();
         String flightId = "expMaxTest";
         stairway.submit(flightId, TestFlightRetry.class, inputParameters);
-        stairway.waitForFlight(flightId);
-        FlightState result = stairway.getFlightState(flightId);
+        FlightState result = stairway.waitForFlight(flightId, null, null);
         LocalDateTime endTime = LocalDateTime.now();
 
         LocalDateTime startRange = startTime.plus(Duration.ofSeconds(14));

--- a/src/test/java/bio/terra/stairway/ScenarioTest.java
+++ b/src/test/java/bio/terra/stairway/ScenarioTest.java
@@ -50,14 +50,13 @@ public class ScenarioTest {
         logger.debug("Flight done: " + done);
 
         // Wait for done
-        stairway.waitForFlight(flightId);
-        FlightState result = stairway.getFlightState(flightId);
+        FlightState result = stairway.waitForFlight(flightId, null, null);
         assertThat(result.getFlightStatus(), CoreMatchers.is(FlightStatus.SUCCESS));
         assertFalse(result.getException().isPresent());
 
-        // Should be released
         try {
-            stairway.waitForFlight(flightId);
+            stairway.deleteFlight(flightId, false);
+            stairway.waitForFlight(flightId, null, null);
         } catch (FlightNotFoundException ex) {
             assertThat(ex.getMessage(), containsString(flightId));
         }
@@ -118,8 +117,7 @@ public class ScenarioTest {
             flightId, TestFlightUndo.class, inputParameters);
 
         // Wait for done
-        stairway.waitForFlight(flightId);
-        FlightState result = stairway.getFlightState(flightId);
+        FlightState result = stairway.waitForFlight(flightId, null, null);
         assertThat(result.getFlightStatus(), is(FlightStatus.ERROR));
         assertTrue(result.getException().isPresent());
         assertThat(result.getException().get().getMessage(), containsString("already exists"));


### PR DESCRIPTION
It is not reliable and won't work when we scale
Re-implemented waitForFlight to poll instead of waiting
on the Future.