### PR TITLE
DR-1297 Provide step class names for logging; quiet down queue logging

### DIFF
--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -23,8 +23,8 @@ import static bio.terra.stairway.FlightStatus.WAITING;
  */
 public class Flight implements Runnable {
   static class StepRetry {
-    private Step step;
-    private RetryRule retryRule;
+    private final Step step;
+    private final RetryRule retryRule;
 
     StepRetry(Step step, RetryRule retryRule) {
       this.step = step;
@@ -32,17 +32,19 @@ public class Flight implements Runnable {
     }
   }
 
-  private static Logger logger = LoggerFactory.getLogger(Flight.class);
+  private static final Logger logger = LoggerFactory.getLogger(Flight.class);
 
-  private List<StepRetry> steps;
+  private final List<StepRetry> steps;
+  private final List<String> stepClassNames;
   private FlightDao flightDao;
   private FlightContext flightContext;
-  private Object applicationContext;
+  private final Object applicationContext;
 
   public Flight(FlightMap inputParameters, Object applicationContext) {
-    flightContext = new FlightContext(inputParameters, this.getClass().getName());
     this.applicationContext = applicationContext;
     steps = new LinkedList<>();
+    stepClassNames = new LinkedList<>();
+    flightContext = new FlightContext(inputParameters, this.getClass().getName(), stepClassNames);
   }
 
   public HookWrapper hookWrapper() {
@@ -58,17 +60,19 @@ public class Flight implements Runnable {
   }
 
   public void setFlightContext(FlightContext flightContext) {
+    flightContext.setStepClassNames(stepClassNames);
     this.flightContext = flightContext;
   }
 
   // Used by subclasses to build the step list with default no-retry rule
   protected void addStep(Step step) {
-    steps.add(new StepRetry(step, RetryRuleNone.getRetryRuleNone()));
+    addStep(step, RetryRuleNone.getRetryRuleNone());
   }
 
   // Used by subclasses to build the step list with a retry rule
   protected void addStep(Step step, RetryRule retryRule) {
     steps.add(new StepRetry(step, retryRule));
+    stepClassNames.add(step.getClass().getName());
   }
 
   /**
@@ -148,12 +152,13 @@ public class Flight implements Runnable {
         return FlightStatus.ERROR;
       }
 
-      // Part 3 - dismal failure
+      // Part 3 - dismal failure - undo failed!
       // Record the undo failure
       flightDao.step(context());
-
-      // Dismal failure - undo failed!
       context().setResult(undoResult);
+      logger.error("DISMAL FAILURE: non-retry-able error during undo. Flight: {}({}) Step: {}({})",
+              context().getFlightId(), context().getFlightClassName(),
+              context().getStepIndex(), context().getStepClassName());
 
     } catch (InterruptedException ex) {
       // Interrupted exception - we assume this means that the thread pool is shutting down and
@@ -174,7 +179,7 @@ public class Flight implements Runnable {
    * recording it into the database.
    *
    * @return StepResult recording the success or failure of the most recent step
-   * @throws InterruptedException
+   * @throws InterruptedException on thread pool shutdown
    */
   private StepResult runSteps()
       throws InterruptedException, StairwayExecutionException, DatabaseOperationException {

--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -1,18 +1,17 @@
 package bio.terra.stairway;
 
+import static bio.terra.stairway.FlightStatus.READY;
+import static bio.terra.stairway.FlightStatus.WAITING;
+
 import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.stairway.exception.StairwayExecutionException;
+import java.util.LinkedList;
+import java.util.List;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.LinkedList;
-import java.util.List;
-
-import static bio.terra.stairway.FlightStatus.READY;
-import static bio.terra.stairway.FlightStatus.WAITING;
 
 /**
  * Manage the atomic execution of a series of Steps This base class has the mechanisms for executing
@@ -156,9 +155,12 @@ public class Flight implements Runnable {
       // Record the undo failure
       flightDao.step(context());
       context().setResult(undoResult);
-      logger.error("DISMAL FAILURE: non-retry-able error during undo. Flight: {}({}) Step: {}({})",
-              context().getFlightId(), context().getFlightClassName(),
-              context().getStepIndex(), context().getStepClassName());
+      logger.error(
+          "DISMAL FAILURE: non-retry-able error during undo. Flight: {}({}) Step: {}({})",
+          context().getFlightId(),
+          context().getFlightClassName(),
+          context().getStepIndex(),
+          context().getStepClassName());
 
     } catch (InterruptedException ex) {
       // Interrupted exception - we assume this means that the thread pool is shutting down and

--- a/src/main/java/bio/terra/stairway/FlightContext.java
+++ b/src/main/java/bio/terra/stairway/FlightContext.java
@@ -12,7 +12,8 @@ import java.util.List;
 public class FlightContext {
   private Stairway stairway; // the stairway instance running this flight
   private String flightId; // unique id for the flight
-  private final String flightClassName; // class name of the flight;  for recreating the flight object
+  private final String
+      flightClassName; // class name of the flight;  for recreating the flight object
   private final FlightMap inputParameters; // allows for reconstructing the flight; set unmodifiable
   private final FlightMap workingMap; // open-ended state used by the steps
   private int stepIndex; // what step we are on
@@ -23,7 +24,8 @@ public class FlightContext {
   private List<String> stepClassNames;
 
   // Construct the context with defaults
-  public FlightContext(FlightMap inputParameters, String flightClassName, List<String> stepClassNames) {
+  public FlightContext(
+      FlightMap inputParameters, String flightClassName, List<String> stepClassNames) {
     this.inputParameters = inputParameters;
     this.inputParameters.makeImmutable();
     this.flightClassName = flightClassName;

--- a/src/main/java/bio/terra/stairway/FlightContext.java
+++ b/src/main/java/bio/terra/stairway/FlightContext.java
@@ -1,6 +1,9 @@
 package bio.terra.stairway;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.List;
 
 /**
  * Context for a flight. This contains the full state for a flight. It is what is held in the
@@ -9,17 +12,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class FlightContext {
   private Stairway stairway; // the stairway instance running this flight
   private String flightId; // unique id for the flight
-  private String flightClassName; // class name of the flight;  for recreating the flight object
-  private FlightMap inputParameters; // allows for reconstructing the flight; set unmodifiable
-  private FlightMap workingMap; // open-ended state used by the steps
+  private final String flightClassName; // class name of the flight;  for recreating the flight object
+  private final FlightMap inputParameters; // allows for reconstructing the flight; set unmodifiable
+  private final FlightMap workingMap; // open-ended state used by the steps
   private int stepIndex; // what step we are on
   private boolean rerun; // true - rerun the current step
   private Direction direction;
   private StepResult result; // current step status
   private FlightStatus flightStatus;
+  private List<String> stepClassNames;
 
   // Construct the context with defaults
-  public FlightContext(FlightMap inputParameters, String flightClassName) {
+  public FlightContext(FlightMap inputParameters, String flightClassName, List<String> stepClassNames) {
     this.inputParameters = inputParameters;
     this.inputParameters.makeImmutable();
     this.flightClassName = flightClassName;
@@ -28,6 +32,7 @@ public class FlightContext {
     this.direction = Direction.START;
     this.result = StepResult.getStepResultSuccess();
     this.flightStatus = FlightStatus.RUNNING;
+    this.stepClassNames = stepClassNames;
   }
 
   public String getFlightId() {
@@ -103,6 +108,21 @@ public class FlightContext {
 
   public void setStairway(Stairway stairway) {
     this.stairway = stairway;
+  }
+
+  public List<String> getStepClassNames() {
+    return stepClassNames;
+  }
+
+  public void setStepClassNames(List<String> stepClassNames) {
+    this.stepClassNames = stepClassNames;
+  }
+
+  public String getStepClassName() {
+    if (stepIndex < 0 || stepIndex >= stepClassNames.size()) {
+      return StringUtils.EMPTY;
+    }
+    return stepClassNames.get(stepIndex);
   }
 
   /**

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -419,8 +419,10 @@ class FlightDao {
         NamedParameterPreparedStatement statement =
             new NamedParameterPreparedStatement(connection, sql)) {
 
-      // My concern, maybe unfounded, is that the snapshot transaction would be reading out of date data,
-      // because there would be too many other transactions writing to the table. Making this a serialized
+      // My concern, maybe unfounded, is that the snapshot transaction would be reading out of date
+      // data,
+      // because there would be too many other transactions writing to the table. Making this a
+      // serialized
       // transaction makes sure that the read transaction is ordered with the write transactions.
       startTransaction(connection);
 
@@ -571,7 +573,9 @@ class FlightDao {
           if (rs.next()) {
             List<FlightInput> inputList = retrieveInputParameters(connection, flightId);
             FlightMap inputParameters = new FlightMap(inputList);
-            flightContext = new FlightContext(inputParameters, rs.getString("class_name"));
+            flightContext =
+                new FlightContext(
+                    inputParameters, rs.getString("class_name"), Collections.EMPTY_LIST);
             flightContext.setFlightId(flightId);
 
             fillFlightContexts(connection, Collections.singletonList(flightContext));

--- a/src/main/java/bio/terra/stairway/HookWrapper.java
+++ b/src/main/java/bio/terra/stairway/HookWrapper.java
@@ -39,13 +39,14 @@ public class HookWrapper {
     try {
       return hookMethod.hook(contextCopy);
     } catch (Exception ex) {
-      logger.info("Stairway Hook failed with exception: {}", ex);
+      logger.info("Stairway Hook failed with exception", ex);
     }
     return HookAction.CONTINUE;
   }
 
   private FlightContext makeCopy(FlightContext fc) {
-    FlightContext fc_new = new FlightContext(fc.getInputParameters(), fc.getFlightClassName());
+    FlightContext fc_new =
+        new FlightContext(fc.getInputParameters(), fc.getFlightClassName(), fc.getStepClassNames());
     fc_new.setDirection(fc.getDirection());
     fc_new.setFlightId(fc.getFlightId());
     fc_new.setFlightStatus(fc.getFlightStatus());

--- a/src/main/java/bio/terra/stairway/QueueCreate.java
+++ b/src/main/java/bio/terra/stairway/QueueCreate.java
@@ -17,12 +17,11 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.TopicName;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressFBWarnings(
     value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -608,7 +608,7 @@ public class Stairway {
    * @return true if there is room to take on more work.
    */
   boolean spaceAvailable() {
-    logger.info(
+    logger.debug(
         "Space available? active: "
             + threadPool.getActiveFlights()
             + " of max: "

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -7,14 +7,6 @@ import bio.terra.stairway.exception.MakeFlightException;
 import bio.terra.stairway.exception.MigrateException;
 import bio.terra.stairway.exception.QueueException;
 import bio.terra.stairway.exception.StairwayExecutionException;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -22,6 +14,13 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.sql.DataSource;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Stairway is the object that drives execution of Flights. */
 public class Stairway {

--- a/src/main/java/bio/terra/stairway/WorkQueueListener.java
+++ b/src/main/java/bio/terra/stairway/WorkQueueListener.java
@@ -28,7 +28,7 @@ public class WorkQueueListener implements Runnable {
   // happens we sleep for NO_PULL_SLEEP_SECONDS and then check the queue depth.
   //
   // The reason to limit to MAX_MESSAGES_PER_PULL is that the evaluation of queue depth is done at,
-  // say,time T0, but the pull will wait for message arrival from pubsub at, say, time T1.
+  // say, time T0, but the pull will wait for message arrival from pubsub at, say, time T1.
   // By time T1, the queue depth situation might have changed. So we don't want to set up to grab
   // lots of messages and then find we are queuing flights way over maxQueuedFlights.
   @Override

--- a/src/main/java/bio/terra/stairway/WorkQueueListener.java
+++ b/src/main/java/bio/terra/stairway/WorkQueueListener.java
@@ -1,8 +1,9 @@
 package bio.terra.stairway;
 
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 public class WorkQueueListener implements Runnable {
   private static final Logger logger = LoggerFactory.getLogger(WorkQueueListener.class);
@@ -24,22 +25,18 @@ public class WorkQueueListener implements Runnable {
   //
   // The algorithm here will pull MAX_MESSAGES_PER_PULL from the queue and resume them, up to the
   // point where the threadPool queue depth is at or over its maxQueuedFlights size. When that
-  // happens
-  // we sleep for NO_PULL_SLEEP_SECONDS and then check the queue depth.
+  // happens we sleep for NO_PULL_SLEEP_SECONDS and then check the queue depth.
   //
   // The reason to limit to MAX_MESSAGES_PER_PULL is that the evaluation of queue depth is done at,
-  // say,
-  // time T0, but the pull will wait for message arrival from pubsub at, say, time T1. By time T1,
-  // the
-  // queue depth situation might have changed. So we don't want to set up to grab lots of messages
-  // and
-  // then find we are queuing flights way over maxQueuedFlights.
+  // say,time T0, but the pull will wait for message arrival from pubsub at, say, time T1.
+  // By time T1, the queue depth situation might have changed. So we don't want to set up to grab
+  // lots of messages and then find we are queuing flights way over maxQueuedFlights.
   @Override
   public void run() {
     try {
       while (!stairway.isQuietingDown()) {
         if (stairway.spaceAvailable()) {
-          logger.info("Asking the work queue for messages: " + MAX_MESSAGES_PER_PULL);
+          logger.debug("Asking the work queue for messages: " + MAX_MESSAGES_PER_PULL);
           workQueue.dispatchMessages(MAX_MESSAGES_PER_PULL, QueueMessage::processMessage);
         } else {
           // No room to queue messages. Take a rest.

--- a/src/test/java/bio/terra/stairway/EnumerateFlightsTest.java
+++ b/src/test/java/bio/terra/stairway/EnumerateFlightsTest.java
@@ -143,7 +143,7 @@ public class EnumerateFlightsTest {
       }
     }
 
-    FlightContext flightContext = new FlightContext(inputParams, className);
+    FlightContext flightContext = new FlightContext(inputParams, className, Collections.EMPTY_LIST);
     flightContext.setFlightId(flightId);
     flightContext.setStairway(stairway);
 

--- a/src/test/java/bio/terra/stairway/QueueFlightTest.java
+++ b/src/test/java/bio/terra/stairway/QueueFlightTest.java
@@ -1,21 +1,20 @@
 package bio.terra.stairway;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import bio.terra.stairway.fixtures.MapKey;
 import bio.terra.stairway.fixtures.TestPauseController;
 import bio.terra.stairway.fixtures.TestUtil;
 import bio.terra.stairway.flights.TestFlightControlledSleep;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("connected")
 public class QueueFlightTest {

--- a/src/test/java/bio/terra/stairway/QueueTest.java
+++ b/src/test/java/bio/terra/stairway/QueueTest.java
@@ -1,5 +1,7 @@
 package bio.terra.stairway;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import bio.terra.stairway.fixtures.TestUtil;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,8 +11,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("connected")
 public class QueueTest {


### PR DESCRIPTION
There are three changes:
1. Set the scheduling and queue logging to debug. get rid of that every five second blat in our data repo logs
2. Build a list of step class names as the flight is being constructed. pass those names over to the flight context so they are available to the hooks.
3. Opportunistically add `final` where IntelliJ tells me to