### PR TITLE
DR-1408 Run hookWrapper#endStep even when the step throws an exception

### DIFF
--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -253,7 +253,6 @@ public class Flight implements Runnable {
         } else {
           result = currentStep.step.undoStep(context());
         }
-        hookWrapper().endStep(flightContext);
       } catch (InterruptedException ex) {
         // Interrupted exception - we assume this means that the thread pool is shutting down and
         // forcibly stopping all threads. We propagate the exception.
@@ -268,6 +267,8 @@ public class Flight implements Runnable {
                 ? StepStatus.STEP_RESULT_FAILURE_RETRY
                 : StepStatus.STEP_RESULT_FAILURE_FATAL;
         result = new StepResult(stepStatus, ex);
+      } finally {
+        hookWrapper().endStep(flightContext);
       }
 
       switch (result.getStepStatus()) {

--- a/src/test/resources/setup-test-env.sh
+++ b/src/test/resources/setup-test-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Sample script to set environment variables for running unit tests
 # This setup matches the setup in the test/resources/create-stairwaylib-db.sql
-export STAIRWAY_USERNAME = 'stairwayuser'
-export STAIRWAY_PASSWORD = 'stairwaypw'
-export STAIRWAY_URI = 'jdbc:postgresql://127.0.0.1:5432/stairwaylib'
+export STAIRWAY_USERNAME='stairwayuser'
+export STAIRWAY_PASSWORD='stairwaypw'
+export STAIRWAY_URI='jdbc:postgresql://127.0.0.1:5432/stairwaylib'


### PR DESCRIPTION
- Put hookWrapper().endStep in a finally so that it is always run, even if the step ends by throwing an exception.
- Fix bash script for setting variables by removing whitespace.

Right now, if the step returns a StepResult error, the endStep on a StairwayHook will run. If the step throws an exception however, Stairway will catch the exception and wrap it as a StepResult error, but not run endStep. We should run the StairwayHook#endStep regardless of how the step finishes.