### PR TITLE
Break duplicate flightID into its own exception

### DIFF
--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -2,6 +2,7 @@ package bio.terra.stairway;
 
 import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.DatabaseSetupException;
+import bio.terra.stairway.exception.DuplicateFlightIdSubmittedException;
 import bio.terra.stairway.exception.FlightException;
 import bio.terra.stairway.exception.MakeFlightException;
 import bio.terra.stairway.exception.MigrateException;
@@ -532,10 +533,12 @@ public class Stairway {
    *     database or launching
    * @throws StairwayExecutionException failure queuing the flight
    * @throws InterruptedException this thread was interrupted
+   * @throws DuplicateFlightIdSubmittedException provided flightId is already in use
    */
   public void submit(
       String flightId, Class<? extends Flight> flightClass, FlightMap inputParameters)
-      throws DatabaseOperationException, StairwayExecutionException, InterruptedException {
+      throws DatabaseOperationException, StairwayExecutionException, InterruptedException,
+          DuplicateFlightIdSubmittedException {
     submitWorker(flightId, flightClass, inputParameters, false);
   }
 
@@ -552,10 +555,12 @@ public class Stairway {
    *     database or launching
    * @throws StairwayExecutionException failure queuing the flight
    * @throws InterruptedException this thread was interrupted
+   * @throws DuplicateFlightIdSubmittedException provided flightId is already in use
    */
   public void submitToQueue(
       String flightId, Class<? extends Flight> flightClass, FlightMap inputParameters)
-      throws DatabaseOperationException, StairwayExecutionException, InterruptedException {
+      throws DatabaseOperationException, StairwayExecutionException, InterruptedException,
+          DuplicateFlightIdSubmittedException {
     submitWorker(flightId, flightClass, inputParameters, true);
   }
 
@@ -564,7 +569,8 @@ public class Stairway {
       Class<? extends Flight> flightClass,
       FlightMap inputParameters,
       boolean shouldQueue)
-      throws DatabaseOperationException, StairwayExecutionException, InterruptedException {
+      throws DatabaseOperationException, StairwayExecutionException, InterruptedException,
+          DuplicateFlightIdSubmittedException {
 
     if (flightClass == null || inputParameters == null) {
       throw new MakeFlightException(

--- a/src/main/java/bio/terra/stairway/exception/DuplicateFlightIdSubmittedException.java
+++ b/src/main/java/bio/terra/stairway/exception/DuplicateFlightIdSubmittedException.java
@@ -1,0 +1,21 @@
+package bio.terra.stairway.exception;
+
+/**
+ * Exception thrown when a flightID that's already in use is submitted.
+ *
+ * <p>Because flightIDs are specified by clients, it's useful to distinguish this case from other
+ * database errors.
+ */
+public class DuplicateFlightIdSubmittedException extends StairwayException {
+  public DuplicateFlightIdSubmittedException(String message) {
+    super(message);
+  }
+
+  public DuplicateFlightIdSubmittedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DuplicateFlightIdSubmittedException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
This adds `DuplicateFlightIdException` as a checked exception in the FlightDAO in the case where a flight is submitted with an ID that's already in use. This is useful for clients providing a flight ID to distinguish duplicate ID exceptions from other generic DB errors.