### PR TITLE
[PF-242] Add StepHook in StairwayHook to support sharing objects between startStep() and endStep()  

### DIFF
--- a/src/main/java/bio/terra/stairway/HookWrapper.java
+++ b/src/main/java/bio/terra/stairway/HookWrapper.java
@@ -46,6 +46,10 @@ public class HookWrapper {
   }
 
   private HookAction handleHook(FlightContext context, HookInterface hookMethod) {
+    if (stairwayHook == null ) {
+      return HookAction.CONTINUE;
+    }
+
     FlightContext contextCopy = makeCopy(context);
     try {
       return hookMethod.hook(contextCopy);

--- a/src/main/java/bio/terra/stairway/HookWrapper.java
+++ b/src/main/java/bio/terra/stairway/HookWrapper.java
@@ -12,29 +12,40 @@ public class HookWrapper {
   }
 
   public HookAction startFlight(FlightContext flightContext) {
-    return handleHook(flightContext, context -> stairwayHook.startFlight(context));
+    return handleFlightHook(flightContext, context -> stairwayHook.startFlight(context));
   }
 
   public HookAction startStep(FlightContext flightContext) {
-    return handleHook(flightContext, context -> stairwayHook.startStep(context));
+    return handleStepHook(flightContext, context -> stairwayHook.newStepHook().startStep(context));
   }
 
   public HookAction endStep(FlightContext flightContext) {
-    return handleHook(flightContext, context -> stairwayHook.endStep(context));
+    return handleStepHook(flightContext, context -> stairwayHook.newStepHook().endStep(context));
   }
 
   public HookAction endFlight(FlightContext flightContext) {
-    return handleHook(flightContext, context -> stairwayHook.endFlight(context));
+    return handleFlightHook(flightContext, context -> stairwayHook.endFlight(context));
   }
 
   private interface HookInterface {
     HookAction hook(FlightContext context) throws InterruptedException;
   }
 
-  private HookAction handleHook(FlightContext context, HookInterface hookMethod) {
-    if (stairwayHook == null) {
+  private HookAction handleStepHook(FlightContext context, HookInterface hookMethod) {
+    if (stairwayHook == null || stairwayHook.newStepHook() == null) {
       return HookAction.CONTINUE;
     }
+    return handleHook(context, hookMethod);
+  }
+
+  private HookAction handleFlightHook(FlightContext context, HookInterface hookMethod) {
+    if (stairwayHook == null ) {
+      return HookAction.CONTINUE;
+    }
+    return handleHook(context, hookMethod);
+  }
+
+  private HookAction handleHook(FlightContext context, HookInterface hookMethod) {
     FlightContext contextCopy = makeCopy(context);
     try {
       return hookMethod.hook(contextCopy);

--- a/src/main/java/bio/terra/stairway/StairwayHook.java
+++ b/src/main/java/bio/terra/stairway/StairwayHook.java
@@ -3,9 +3,7 @@ package bio.terra.stairway;
 public interface StairwayHook {
   HookAction startFlight(FlightContext context) throws InterruptedException;
 
-  HookAction startStep(FlightContext context) throws InterruptedException;
-
   HookAction endFlight(FlightContext context) throws InterruptedException;
 
-  HookAction endStep(FlightContext context) throws InterruptedException;
+  StepHook newStepHook();
 }

--- a/src/main/java/bio/terra/stairway/StepHook.java
+++ b/src/main/java/bio/terra/stairway/StepHook.java
@@ -1,0 +1,6 @@
+package bio.terra.stairway;
+
+public interface StepHook {
+  HookAction startStep(FlightContext flightContext);
+  HookAction endStep(FlightContext flightContext);
+}

--- a/src/main/java/bio/terra/stairway/StepHook.java
+++ b/src/main/java/bio/terra/stairway/StepHook.java
@@ -1,6 +1,8 @@
 package bio.terra.stairway;
 
+/** An interface to plugin code before and after each Flight step.  */
 public interface StepHook {
-  HookAction startStep(FlightContext flightContext);
-  HookAction endStep(FlightContext flightContext);
+  HookAction startStep(FlightContext flightContext) throws InterruptedException;
+
+  HookAction endStep(FlightContext flightContext) throws InterruptedException;
 }


### PR DESCRIPTION
Reason we want that: In Buffer Service, we want to use Hook to track the tracing of a flight. And we will have something like this:
```
startStep(FlightContext context) {
  startSpan()
}

endStep(FlightContext context) {
 endSpan()
}
```

But to end the span. we need to get the spanContext which is created in startSpan(). 

Would be great if we can pass the spanContext around. 