### PR TITLE
PF-351: Detailed retry logging

### DIFF
--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -328,7 +328,7 @@ public class Flight implements Runnable {
             logger.info("Quieting down - not retrying: " + context().prettyStepState());
             return result;
           }
-          logger.info("Retrying: " + context().prettyStepState());
+          logger.info("Invoking retry rule: " + context().prettyStepState());
           break;
 
         default:

--- a/src/main/java/bio/terra/stairway/FlightFactory.java
+++ b/src/main/java/bio/terra/stairway/FlightFactory.java
@@ -13,6 +13,7 @@ public interface FlightFactory {
    * @param flightClass class of the flight to create
    * @param inputParameters input FlightMap for the constructor - as supplied on the submit call
    * @param context application context for the flight - as supplied to the Stairway builder
+   * @param debugInfo optional debug information for flight testing
    * @return Subclass of the Flight class
    */
   Flight makeFlight(
@@ -27,6 +28,7 @@ public interface FlightFactory {
    * @param className string name of the class to construct
    * @param inputMap input FlightMap for the constructor
    * @param context application context for the flight - as supplied to the Stairway builder
+   * @param debugInfo optional debug information for flight testing
    * @return Subclass of the Flight class
    */
   Flight makeFlightFromName(

--- a/src/main/java/bio/terra/stairway/RetryRuleExponentialBackoff.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleExponentialBackoff.java
@@ -1,7 +1,7 @@
 package bio.terra.stairway;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +13,7 @@ public class RetryRuleExponentialBackoff implements RetryRule {
   private final long maxIntervalSeconds;
   private final long maxOperationTimeSeconds;
 
-  private LocalDateTime endTime;
+  private Instant endTime;
   private long intervalSeconds;
 
   /**
@@ -33,12 +33,12 @@ public class RetryRuleExponentialBackoff implements RetryRule {
   @Override
   public void initialize() {
     intervalSeconds = initialIntervalSeconds;
-    endTime = LocalDateTime.now().plus(Duration.ofSeconds(maxOperationTimeSeconds));
+    endTime = Instant.now().plus(Duration.ofSeconds(maxOperationTimeSeconds));
   }
 
   @Override
   public boolean retrySleep() throws InterruptedException {
-    LocalDateTime now = LocalDateTime.now();
+    Instant now = Instant.now();
     if (now.isAfter(endTime)) {
       logger.info(
           "Retry rule exponential: now ({}) is past max time {} - not retrying", now, endTime);

--- a/src/main/java/bio/terra/stairway/RetryRuleExponentialBackoff.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleExponentialBackoff.java
@@ -3,8 +3,12 @@ package bio.terra.stairway;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RetryRuleExponentialBackoff implements RetryRule {
+  private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);
+
   private final long initialIntervalSeconds;
   private final long maxIntervalSeconds;
   private final long maxOperationTimeSeconds;
@@ -34,9 +38,18 @@ public class RetryRuleExponentialBackoff implements RetryRule {
 
   @Override
   public boolean retrySleep() throws InterruptedException {
-    if (LocalDateTime.now().isAfter(endTime)) {
+    LocalDateTime now = LocalDateTime.now();
+    if (now.isAfter(endTime)) {
+      logger.info(
+          "Retry rule exponential: now ({}) is past max time {} - not retrying", now, endTime);
       return false;
     }
+
+    logger.info(
+        "Retry rule exponential: now ({}) is before {} - retrying after sleep of {} seconds",
+        now,
+        endTime,
+        intervalSeconds);
 
     TimeUnit.SECONDS.sleep(intervalSeconds);
     intervalSeconds = intervalSeconds + intervalSeconds;

--- a/src/main/java/bio/terra/stairway/RetryRuleFixedInterval.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleFixedInterval.java
@@ -1,8 +1,9 @@
 package bio.terra.stairway;
 
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 public class RetryRuleFixedInterval implements RetryRule {
   private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);
@@ -33,19 +34,19 @@ public class RetryRuleFixedInterval implements RetryRule {
 
   @Override
   public boolean retrySleep() throws InterruptedException {
-    if (retryCount >= maxCount) {
-      logger.info("Retry rule fixed: try {} of {} - not retrying", retryCount, maxCount);
+    retryCount++;
+    if (retryCount > maxCount) {
+      logger.info("Retry rule fixed: retried {} times - not retrying", maxCount);
       return false;
     }
 
     logger.info(
-        "Retry rule fixed: try {} of {} - retrying after sleep of {} seconds",
+        "Retry rule fixed: starting retry {} of {} after sleep of {} seconds",
         retryCount,
         maxCount,
         intervalSeconds);
 
     TimeUnit.SECONDS.sleep(intervalSeconds);
-    retryCount++;
     return true;
   }
 }

--- a/src/main/java/bio/terra/stairway/RetryRuleFixedInterval.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleFixedInterval.java
@@ -1,11 +1,15 @@
 package bio.terra.stairway;
 
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RetryRuleFixedInterval implements RetryRule {
+  private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);
+
   // Fixed parameters
-  private int intervalSeconds;
-  private int maxCount;
+  private final int intervalSeconds;
+  private final int maxCount;
 
   // Initialized parameters
   private int retryCount;
@@ -30,8 +34,15 @@ public class RetryRuleFixedInterval implements RetryRule {
   @Override
   public boolean retrySleep() throws InterruptedException {
     if (retryCount >= maxCount) {
+      logger.info("Retry rule fixed: try {} of {} - not retrying", retryCount, maxCount);
       return false;
     }
+
+    logger.info(
+        "Retry rule fixed: try {} of {} - retrying after sleep of {} seconds",
+        retryCount,
+        maxCount,
+        intervalSeconds);
 
     TimeUnit.SECONDS.sleep(intervalSeconds);
     retryCount++;

--- a/src/main/java/bio/terra/stairway/RetryRuleNone.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleNone.java
@@ -1,7 +1,12 @@
 package bio.terra.stairway;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class RetryRuleNone implements RetryRule {
-  private static RetryRuleNone retryRuleNoneSingleton = new RetryRuleNone();
+  private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);
+
+  private static final RetryRuleNone retryRuleNoneSingleton = new RetryRuleNone();
 
   public static RetryRuleNone getRetryRuleNone() {
     return retryRuleNoneSingleton;
@@ -12,6 +17,7 @@ public class RetryRuleNone implements RetryRule {
 
   @Override
   public boolean retrySleep() throws InterruptedException {
+    logger.info("Retry rule none invoked - no retry");
     return false;
   }
 }

--- a/src/main/java/bio/terra/stairway/RetryRuleRandomBackoff.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleRandomBackoff.java
@@ -1,9 +1,10 @@
 package bio.terra.stairway;
 
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 public class RetryRuleRandomBackoff implements RetryRule {
   private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);
@@ -39,21 +40,21 @@ public class RetryRuleRandomBackoff implements RetryRule {
 
   @Override
   public boolean retrySleep() throws InterruptedException {
-    if (retryCount >= maxCount) {
-      logger.info("Retry rule random: try {} of {} - not retrying", retryCount, maxCount);
+    retryCount++;
+    if (retryCount > maxCount) {
+      logger.info("Retry rule random: retried {} times - not retrying", maxCount);
       return false;
     }
 
     int sleepUnits = ThreadLocalRandom.current().nextInt(0, maxConcurrency);
     long ms = sleepUnits * operationIncrementMilliseconds;
     logger.info(
-        "Retry rule random: try {} of {} - retrying after sleep of {} milliseconds",
+        "Retry rule random: starting retry {} of {} after sleep of {} milliseconds",
         retryCount,
         maxCount,
         ms);
 
     TimeUnit.MILLISECONDS.sleep(ms);
-    retryCount++;
     return true;
   }
 }

--- a/src/main/java/bio/terra/stairway/RetryRuleRandomBackoff.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleRandomBackoff.java
@@ -2,8 +2,12 @@ package bio.terra.stairway;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RetryRuleRandomBackoff implements RetryRule {
+  private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);
+
   private final long operationIncrementMilliseconds;
   private final int maxConcurrency;
   private final int maxCount;
@@ -12,7 +16,7 @@ public class RetryRuleRandomBackoff implements RetryRule {
   private int retryCount;
 
   /**
-   * Retry with random backoff for concurrent threads Assume operation requires
+   * Retry with random backoff for concurrent threads. Assume operation requires
    * operationIncrementMilliseconds. We want to spread maxConcurrency threads so that we will do
    * roughly one at a time. So we get a random integer between 0 and maxConcurrency-1 and multiply
    * that by the operation time. We sleep that long and retry.
@@ -36,11 +40,19 @@ public class RetryRuleRandomBackoff implements RetryRule {
   @Override
   public boolean retrySleep() throws InterruptedException {
     if (retryCount >= maxCount) {
+      logger.info("Retry rule random: try {} of {} - not retrying", retryCount, maxCount);
       return false;
     }
 
     int sleepUnits = ThreadLocalRandom.current().nextInt(0, maxConcurrency);
-    TimeUnit.MILLISECONDS.sleep(sleepUnits * operationIncrementMilliseconds);
+    long ms = sleepUnits * operationIncrementMilliseconds;
+    logger.info(
+        "Retry rule random: try {} of {} - retrying after sleep of {} milliseconds",
+        retryCount,
+        maxCount,
+        ms);
+
+    TimeUnit.MILLISECONDS.sleep(ms);
     retryCount++;
     return true;
   }

--- a/src/test/java/bio/terra/stairway/RetryTest.java
+++ b/src/test/java/bio/terra/stairway/RetryTest.java
@@ -128,4 +128,22 @@ public class RetryTest {
     assertThat(result.getFlightStatus(), is(FlightStatus.SUCCESS));
     assertFalse(result.getException().isPresent());
   }
+
+  @Test
+  public void randomFailureTest() throws Exception {
+    // Should fail by running out of tries, like fixed
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put("retryType", "random");
+    inputParameters.put("failCount", 4);
+    inputParameters.put("operationMilliseconds", 500L);
+    inputParameters.put("maxConcurrency", 5);
+    inputParameters.put("maxCount", 3);
+
+    String flightId = "randomFailureTest";
+    stairway.submit(flightId, TestFlightRetry.class, inputParameters);
+
+    FlightState result = stairway.waitForFlight(flightId, null, null);
+    assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.ERROR)));
+    assertTrue(result.getException().isPresent());
+  }
 }

--- a/src/test/java/bio/terra/stairway/flights/TestFlightMultiStepRetry.java
+++ b/src/test/java/bio/terra/stairway/flights/TestFlightMultiStepRetry.java
@@ -15,7 +15,6 @@ public class TestFlightMultiStepRetry extends Flight {
 
     // Pull out our parameters and feed them in to the step classes.
     String retryType = inputParameters.get("retryType", String.class);
-    Integer failCount = inputParameters.get("failCount", Integer.class);
 
     if (StringUtils.equals("fixed", retryType)) {
       Integer intervalSeconds = inputParameters.get("intervalSeconds", Integer.class);

--- a/src/test/java/bio/terra/stairway/flights/TestFlightRetry.java
+++ b/src/test/java/bio/terra/stairway/flights/TestFlightRetry.java
@@ -5,6 +5,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
 import bio.terra.stairway.RetryRuleFixedInterval;
+import bio.terra.stairway.RetryRuleRandomBackoff;
 import org.apache.commons.lang3.StringUtils;
 
 public class TestFlightRetry extends Flight {
@@ -29,11 +30,15 @@ public class TestFlightRetry extends Flight {
       retryRule =
           new RetryRuleExponentialBackoff(
               initialIntervalSeconds, maxIntervalSeconds, maxOperationTimeSeconds);
+    } else if (StringUtils.equals("random", retryType)) {
+      long operationMilliseconds = inputParameters.get("operationMilliseconds", Long.class);
+      int maxConcurrency = inputParameters.get("maxConcurrency", Integer.class);
+      int maxCount = inputParameters.get("maxCount", Integer.class);
+      retryRule = new RetryRuleRandomBackoff(operationMilliseconds, maxConcurrency, maxCount);
     } else {
       throw new IllegalArgumentException("Invalid inputParameter retryType");
     }
 
-    // Step 1 - test file existence
     addStep(new TestStepRetry(failCount), retryRule);
   }
 }


### PR DESCRIPTION
Added detailed retry logging within the retry rules.
Fixed the wording of the outer retry log message so it is not misleading.
Added a test for randomBackoff.
Validated the new logging by examining the output of the retry test.

In addition, fixed a javadoc complaint (FlightFactory) and a spotbugs complaint (TestFlightMultiStepRetry)
