### PR TITLE
PF-311 hook enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 
 group 'bio.terra'
 version '0.0.25-SNAPSHOT'
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_11
 
 // TODO: there may be a better way to supply these values than envvars.
 // This and the test below makes sure the build will fail reasonably if you try

--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -44,7 +44,7 @@ public class Flight implements Runnable {
 
   // This list will only be populated if debugInfo.FailAtSteps is populated. If so, this
   // keeps track of which steps have already been failed so we do not infinitely retry.
-  private Set<Integer> debugStepsFailed;
+  private final Set<Integer> debugStepsFailed;
 
   public Flight(FlightMap inputParameters, Object applicationContext) {
     this.applicationContext = applicationContext;

--- a/src/main/java/bio/terra/stairway/FlightContext.java
+++ b/src/main/java/bio/terra/stairway/FlightContext.java
@@ -1,8 +1,9 @@
 package bio.terra.stairway;
 
-import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.List;
 
 /**
  * Context for a flight. This contains the full state for a flight. It is what is held in the
@@ -11,8 +12,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class FlightContext {
   private Stairway stairway; // the stairway instance running this flight
   private String flightId; // unique id for the flight
-  private final String
-      flightClassName; // class name of the flight;  for recreating the flight object
+  private final String flightClassName; // class name of the flight
   private final FlightMap inputParameters; // allows for reconstructing the flight; set unmodifiable
   private final FlightMap workingMap; // open-ended state used by the steps
   private int stepIndex; // what step we are on
@@ -22,6 +22,7 @@ public class FlightContext {
   private FlightStatus flightStatus;
   private List<String> stepClassNames;
   private FlightDebugInfo debugInfo;
+  private List<StepHook> stepHooks;
 
   // Construct the context with defaults
   public FlightContext(
@@ -133,6 +134,14 @@ public class FlightContext {
 
   public FlightDebugInfo getDebugInfo() {
     return debugInfo;
+  }
+
+  public List<StepHook> getStepHooks() {
+    return stepHooks;
+  }
+
+  public void setStepHooks(List<StepHook> stepHooks) {
+    this.stepHooks = stepHooks;
   }
 
   /**

--- a/src/main/java/bio/terra/stairway/FlightContext.java
+++ b/src/main/java/bio/terra/stairway/FlightContext.java
@@ -1,9 +1,8 @@
 package bio.terra.stairway;
 
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-
-import java.util.List;
 
 /**
  * Context for a flight. This contains the full state for a flight. It is what is held in the

--- a/src/main/java/bio/terra/stairway/FlightContext.java
+++ b/src/main/java/bio/terra/stairway/FlightContext.java
@@ -9,18 +9,56 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * database for the flight and it is passed into the steps
  */
 public class FlightContext {
-  private Stairway stairway; // the stairway instance running this flight
-  private String flightId; // unique id for the flight
-  private final String flightClassName; // class name of the flight
-  private final FlightMap inputParameters; // allows for reconstructing the flight; set unmodifiable
-  private final FlightMap workingMap; // open-ended state used by the steps
-  private int stepIndex; // what step we are on
-  private boolean rerun; // true - rerun the current step
+  /** The stairway instance running this flight */
+  private Stairway stairway;
+
+  /**
+   * Identifier for the flight. The caller is expected to ensure that these are unique within this
+   * Stairway.
+   */
+  private String flightId;
+
+  /**
+   * Full class name of the flight. This is used to reconstruct the flight from its persisted state.
+   */
+  private final String flightClassName;
+
+  /** Unmodifiable flight map of the input parameters to the flight */
+  private final FlightMap inputParameters;
+
+  /**
+   * Modifiable flight map used to communicate state between steps and convey output of the flight.
+   */
+  private final FlightMap workingMap;
+
+  /** Index into the flight's step array of the step we are */
+  private int stepIndex;
+
+  /** Control flag to tell the flight runner to rerun the current step */
+  private boolean rerun;
+
+  /** Direction of execution: do, undo, switch. */
   private Direction direction;
-  private StepResult result; // current step status
+
+  /** Returned status of the current step */
+  private StepResult result;
+
+  /** State of this flight */
   private FlightStatus flightStatus;
+
+  /**
+   * List of the class names of the steps. This is not used by the flight execution code. It is here
+   * to allow more meaningful log messages by hooks.
+   */
   private List<String> stepClassNames;
+
+  /** Debug control of this flight. */
   private FlightDebugInfo debugInfo;
+
+  /**
+   * Dynamic list of step hooks defined for the current step, created using {@link
+   * StairwayHook#stepFactory(FlightContext)}
+   */
   private List<StepHook> stepHooks;
 
   // Construct the context with defaults

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -370,7 +370,7 @@ class FlightDao {
           throw new DatabaseOperationException(
               String.format(
                   "Failed to update status to %s for flight: %s",
-                  flightContext.getFlightStatus().name(), flightContext.getFlightId()),
+                  flightContext.getFlightStatus(), flightContext.getFlightId()),
               ex);
         }
       }

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -62,10 +62,16 @@ class FlightDao {
   private final DataSource dataSource;
   private final ExceptionSerializer exceptionSerializer;
   private final boolean keepFlightLog;
+  private final HookWrapper hookWrapper;
 
-  FlightDao(DataSource dataSource, ExceptionSerializer exceptionSerializer, boolean keepFlightLog) {
+  FlightDao(
+      DataSource dataSource,
+      ExceptionSerializer exceptionSerializer,
+      HookWrapper hookWrapper,
+      boolean keepFlightLog) {
     this.dataSource = dataSource;
     this.exceptionSerializer = exceptionSerializer;
+    this.hookWrapper = hookWrapper;
     this.keepFlightLog = keepFlightLog;
   }
 
@@ -161,7 +167,7 @@ class FlightDao {
    * drive recovery of orphaned flights.
    *
    * @return list of the stairway instances known to stairway
-   * @throws DatabaseOperationException
+   * @throws DatabaseOperationException on SQL exception
    */
   List<String> getStairwayInstanceList() throws DatabaseOperationException {
     final String sql = "SELECT stairway_name FROM " + STAIRWAY_INSTANCE_TABLE;
@@ -220,6 +226,7 @@ class FlightDao {
           connection, flightContext.getFlightId(), flightContext.getInputParameters());
 
       commitTransaction(connection);
+      hookWrapper.stateTransition(flightContext);
     } catch (SQLException ex) {
       // SQL state 23505 indicates a unique key violation, which in this case indicates a duplicate
       // flightId. See https://www.postgresql.org/docs/10/errcodes-appendix.html for postgres
@@ -228,7 +235,7 @@ class FlightDao {
         throw new DuplicateFlightIdSubmittedException(
             "Duplicate flightID " + flightContext.getFlightId(), ex);
       }
-      handleSqlException("Failed to create database tables", ex, flightContext);
+      handleSqlException("Failed to insert flight record - submit failed", ex, flightContext);
     }
   }
 
@@ -256,6 +263,7 @@ class FlightDao {
       statement.setString("direction", flightContext.getDirection().name());
       statement.setBoolean("succeeded", flightContext.getResult().isSuccess());
       statement.setString("serializedException", serializedException);
+      // TODO: I believe storing this is useless. The status always RUNNING
       statement.setString("status", flightContext.getFlightStatus().name());
       statement.getPreparedStatement().executeUpdate();
       commitTransaction(connection);
@@ -265,13 +273,8 @@ class FlightDao {
   }
 
   /**
-   * Record the exiting of the flight. It may be exiting because
-   *
-   * <ul>
-   *   <li>it is done
-   *   <li>it asked for a long wait
-   *   <li>stairway is shutting down
-   * </ul>
+   * Record the exiting of the flight. In this case, we interpret the flight status as the target
+   * status for the flight.
    *
    * @param flightContext context object for the flight
    * @throws DatabaseOperationException on database errors
@@ -293,7 +296,8 @@ class FlightDao {
         break;
 
       case QUEUED:
-        queued(flightContext.getFlightId());
+        queued(flightContext);
+        break;
 
       case RUNNING:
       default:
@@ -317,16 +321,17 @@ class FlightDao {
    * chances of getting multiple entries for the same flight in the queue. However, by the time we
    * do this, another Stairway instance might already have pulled it from the queue and run it.
    *
-   * @param flightId identifier for this flight
+   * @param flightContext context for this flight
    * @throws DatabaseOperationException on database errors
    */
-  void queued(String flightId) throws DatabaseOperationException, InterruptedException {
+  void queued(FlightContext flightContext) throws DatabaseOperationException, InterruptedException {
     final String sqlUpdateFlight =
         "UPDATE "
             + FLIGHT_TABLE
             + " SET status = :status"
             + " WHERE stairway_id IS NULL AND flightid = :flightId AND status = 'READY'";
-    updateFlightState("queued", sqlUpdateFlight, flightId, "QUEUED");
+    flightContext.setFlightStatus(FlightStatus.QUEUED);
+    updateFlightState("queued", sqlUpdateFlight, flightContext);
   }
 
   /**
@@ -343,14 +348,10 @@ class FlightDao {
             + " SET status = :status,"
             + " stairway_id = NULL"
             + " WHERE flightid = :flightId AND status = 'RUNNING'";
-    updateFlightState(
-        "disown",
-        sqlUpdateFlight,
-        flightContext.getFlightId(),
-        flightContext.getFlightStatus().name());
+    updateFlightState("disown", sqlUpdateFlight, flightContext);
   }
 
-  private void updateFlightState(String comment, String sql, String flightId, String status)
+  private void updateFlightState(String comment, String sql, FlightContext flightContext)
       throws DatabaseOperationException, InterruptedException {
 
     for (int retry = 0; retry < SERIALIZATION_RETRIES; retry++) {
@@ -359,18 +360,22 @@ class FlightDao {
               new NamedParameterPreparedStatement(connection, sql)) {
 
         startTransaction(connection);
-        statement.setString("status", status);
-        statement.setString("flightId", flightId);
+        statement.setString("status", flightContext.getFlightStatus().name());
+        statement.setString("flightId", flightContext.getFlightId());
         statement.getPreparedStatement().executeUpdate();
         commitTransaction(connection);
+        hookWrapper.stateTransition(flightContext);
         break;
       } catch (SQLException ex) {
         if (!retrySqlException(ex)) {
           throw new DatabaseOperationException(
-              "Failed to update status to " + status + " for flight: " + flightId, ex);
+              String.format(
+                  "Failed to update status to %s for flight: %s",
+                  flightContext.getFlightStatus().name(), flightContext.getFlightId()),
+              ex);
         }
       }
-      retryWait(comment, flightId);
+      retryWait(comment, flightContext.getFlightId());
     }
   }
 
@@ -385,7 +390,12 @@ class FlightDao {
    * @throws InterruptedException interruption of the retry loop
    */
   void disownRecovery(String stairwayId) throws DatabaseOperationException, InterruptedException {
-    final String sql =
+    final String sqlGet =
+        "SELECT flightid, class_name, debug_info, status FROM "
+            + FLIGHT_TABLE
+            + " WHERE stairway_id = :stairwayId AND status = 'RUNNING'";
+
+    final String sqlUpdate =
         "UPDATE "
             + FLIGHT_TABLE
             + " SET status = 'READY', stairway_id = NULL"
@@ -396,20 +406,40 @@ class FlightDao {
 
     for (int retry = 0; retry < SERIALIZATION_RETRIES; retry++) {
       try (Connection connection = dataSource.getConnection();
-          NamedParameterPreparedStatement statement =
-              new NamedParameterPreparedStatement(connection, sql);
+          NamedParameterPreparedStatement getStatement =
+              new NamedParameterPreparedStatement(connection, sqlGet);
+          NamedParameterPreparedStatement updateStatement =
+              new NamedParameterPreparedStatement(connection, sqlUpdate);
           NamedParameterPreparedStatement deleteStatement =
               new NamedParameterPreparedStatement(connection, sqlDelete)) {
 
         startTransaction(connection);
-        statement.setString("stairwayId", stairwayId);
-        int disownCount = statement.getPreparedStatement().executeUpdate();
-        logger.info("Disowned " + disownCount + " flights for stairway: " + stairwayId);
+        getStatement.setString("stairwayId", stairwayId);
+        List<FlightContext> flightList = new ArrayList<>();
+        try (ResultSet rs = getStatement.getPreparedStatement().executeQuery()) {
+          while (rs.next()) {
+            FlightContext flightContext =
+                makeFlightContext(connection, rs.getString("flightid"), rs);
+            flightContext.setFlightStatus(FlightStatus.READY);
+            flightList.add(flightContext);
+          }
+        }
+
+        if (!flightList.isEmpty()) {
+          updateStatement.setString("stairwayId", stairwayId);
+          int disownCount = updateStatement.getPreparedStatement().executeUpdate();
+          logger.info("Disowned " + disownCount + " flights for stairway: " + stairwayId);
+        }
 
         deleteStatement.setString("stairwayId", stairwayId);
         deleteStatement.getPreparedStatement().executeUpdate();
 
         commitTransaction(connection);
+
+        // Call the state hook for each of the flights we found
+        for (FlightContext flightContext : flightList) {
+          hookWrapper.stateTransition(flightContext);
+        }
         break;
       } catch (SQLException ex) {
         if (!retrySqlException(ex)) {
@@ -510,6 +540,7 @@ class FlightDao {
         }
 
         commitTransaction(connection);
+        hookWrapper.stateTransition(flightContext);
         break;
       } catch (SQLException ex) {
         if (!retrySqlException(ex)) {
@@ -567,7 +598,7 @@ class FlightDao {
   FlightContext resume(String stairwayId, String flightId)
       throws DatabaseOperationException, InterruptedException {
     final String sqlUnownedFlight =
-        "SELECT class_name, debug_info "
+        "SELECT class_name, debug_info, status "
             + " FROM "
             + FLIGHT_TABLE
             + " WHERE (status = 'WAITING' OR status = 'READY' OR status = 'QUEUED' OR status = 'READY_TO_RESTART')"
@@ -593,23 +624,8 @@ class FlightDao {
         FlightContext flightContext = null;
         try (ResultSet rs = unownedFlightStatement.getPreparedStatement().executeQuery()) {
           if (rs.next()) {
-            List<FlightInput> inputList = retrieveInputParameters(connection, flightId);
-            FlightMap inputParameters = new FlightMap(inputList);
-            FlightDebugInfo debugInfo = null;
-            try {
-              debugInfo =
-                  FlightDebugInfo.getObjectMapper()
-                      .readValue(rs.getString("debug_info"), FlightDebugInfo.class);
-            } catch (JsonProcessingException e) {
-              throw new DatabaseOperationException(e);
-            }
-            flightContext =
-                new FlightContext(
-                    inputParameters, rs.getString("class_name"), Collections.EMPTY_LIST);
-            flightContext.setDebugInfo(debugInfo);
-            flightContext.setFlightId(flightId);
-
-            fillFlightContexts(connection, Collections.singletonList(flightContext));
+            flightContext = makeFlightContext(connection, flightId, rs);
+            flightContext.setFlightStatus(FlightStatus.RUNNING);
           }
         }
 
@@ -621,6 +637,10 @@ class FlightDao {
         }
 
         commitTransaction(connection);
+
+        if (flightContext != null) {
+          hookWrapper.stateTransition(flightContext);
+        }
         return flightContext;
       } catch (SQLException ex) {
         if (!retrySqlException(ex)) {
@@ -631,6 +651,65 @@ class FlightDao {
       retryWait("resume", flightId);
     }
     return null;
+  }
+
+  FlightContext makeFlightContextById(String flightId)
+      throws DatabaseOperationException, InterruptedException {
+    final String sqlGetFlight =
+        "SELECT class_name, debug_info, status "
+            + " FROM "
+            + FLIGHT_TABLE
+            + " WHERE flightid = :flightId";
+
+    for (int retry = 0; retry < SERIALIZATION_RETRIES; retry++) {
+      try (Connection connection = dataSource.getConnection();
+          NamedParameterPreparedStatement getFlightStatement =
+              new NamedParameterPreparedStatement(connection, sqlGetFlight)) {
+
+        startTransaction(connection);
+
+        getFlightStatement.setString("flightId", flightId);
+        FlightContext flightContext = null;
+        try (ResultSet rs = getFlightStatement.getPreparedStatement().executeQuery()) {
+          if (rs.next()) {
+            flightContext = makeFlightContext(connection, flightId, rs);
+          }
+        }
+        commitTransaction(connection);
+        return flightContext;
+      } catch (SQLException ex) {
+        if (!retrySqlException(ex)) {
+          handleSqlException("Failed to get flight", ex);
+          return null;
+        }
+      }
+      retryWait("makeFlight", flightId);
+    }
+    return null;
+  }
+
+  // The results set must be positioned at a row from the flight table,
+  // and the select list must include debug_info, class_name, and status.
+  private FlightContext makeFlightContext(Connection connection, String flightId, ResultSet rs)
+      throws InterruptedException, DatabaseOperationException, SQLException {
+    List<FlightInput> inputList = retrieveInputParameters(connection, flightId);
+    FlightMap inputParameters = new FlightMap(inputList);
+    FlightDebugInfo debugInfo = null;
+    try {
+      debugInfo =
+          FlightDebugInfo.getObjectMapper()
+              .readValue(rs.getString("debug_info"), FlightDebugInfo.class);
+    } catch (JsonProcessingException e) {
+      throw new DatabaseOperationException(e);
+    }
+    FlightContext flightContext =
+        new FlightContext(inputParameters, rs.getString("class_name"), Collections.emptyList());
+    flightContext.setDebugInfo(debugInfo);
+    flightContext.setFlightId(flightId);
+
+    fillFlightContexts(connection, Collections.singletonList(flightContext));
+    flightContext.setFlightStatus(FlightStatus.valueOf(rs.getString("status")));
+    return flightContext;
   }
 
   /**

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -8,10 +8,6 @@ import bio.terra.stairway.exception.FlightFilterException;
 import bio.terra.stairway.exception.FlightNotFoundException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -20,6 +16,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The general layout of the stairway database tables is:

--- a/src/main/java/bio/terra/stairway/HookWrapper.java
+++ b/src/main/java/bio/terra/stairway/HookWrapper.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,15 +13,46 @@ public class HookWrapper {
   private final List<StairwayHook> stairwayHooks;
 
   private enum HookOperation {
-    START_FLIGHT,
-    START_STEP,
-    END_STEP,
-    END_FLIGHT,
-    STATE_TRANSITION
+    START_FLIGHT {
+      void handleHook(FlightContext context, StairwayHook stairwayHook) throws InterruptedException {
+        stairwayHook.startFlight(context);
+      }
+    },
+    START_STEP {
+      void handleHook(FlightContext context, StairwayHook stairwayHook) throws InterruptedException {
+        stairwayHook.startStep(context);
+      }
+
+      void handleStepHook(FlightContext context, StepHook stepHook) throws InterruptedException {
+        stepHook.startStep(context);
+      }
+    },
+    END_STEP {
+      void handleHook(FlightContext context, StairwayHook stairwayHook) throws InterruptedException {
+        stairwayHook.endStep(context);
+      }
+
+      void handleStepHook(FlightContext context, StepHook stepHook) throws InterruptedException {
+        stepHook.endStep(context);
+      }
+    },
+    END_FLIGHT {
+      void handleHook(FlightContext context, StairwayHook stairwayHook) throws InterruptedException {
+        stairwayHook.endFlight(context);
+      }
+    },
+    STATE_TRANSITION {
+      void handleHook(FlightContext context, StairwayHook stairwayHook) throws InterruptedException {
+        stairwayHook.stateTransition(context);
+      }
+    };
+
+    abstract void handleHook(FlightContext context, StairwayHook stairwayHook) throws InterruptedException;
+    void handleStepHook(FlightContext context, StepHook stepHook) throws InterruptedException { }
   }
 
   public HookWrapper(List<StairwayHook> stairwayHooks) {
-    this.stairwayHooks = stairwayHooks;
+    this.stairwayHooks = stairwayHooks != null ? stairwayHooks : Collections.emptyList();
   }
 
   public void startFlight(FlightContext flightContext) {
@@ -28,67 +60,37 @@ public class HookWrapper {
   }
 
   public void startStep(FlightContext flightContext) throws InterruptedException {
-    if (stairwayHooks != null) {
-      FlightContext contextCopy = makeCopy(flightContext);
-      // First handle plain step hooks
-      handleHookList(contextCopy, HookOperation.START_STEP);
-      // Use the factory to collect any step hooks for this step
-      List<StepHook> stepHooks = new ArrayList<>();
-      for (StairwayHook stairwayHook : stairwayHooks) {
-        Optional<StepHook> maybeStepHook = stairwayHook.stepFactory(contextCopy);
-        maybeStepHook.ifPresent(stepHooks::add);
-      }
-      // Then handle an step hooks list from the factory
-      handleStepHookList(stepHooks, contextCopy, HookOperation.START_STEP);
-      flightContext.setStepHooks(stepHooks);
+    // First handle plain step hooks
+    handleHookList(flightContext, HookOperation.START_STEP);
+    // Use the factory to collect any step hooks for this step
+    List<StepHook> stepHooks = new ArrayList<>();
+    for (StairwayHook stairwayHook : stairwayHooks) {
+      Optional<StepHook> maybeStepHook = stairwayHook.stepFactory(flightContext);
+      maybeStepHook.ifPresent(stepHooks::add);
     }
+    // Then handle an step hooks list from the factory
+    handleStepHookList(stepHooks, flightContext, HookOperation.START_STEP);
+    flightContext.setStepHooks(stepHooks);
   }
 
   public void endStep(FlightContext flightContext) {
-    if (stairwayHooks != null) {
-      FlightContext contextCopy = makeCopy(flightContext);
-      // First handle plain step hooks
-      handleHookList(contextCopy, HookOperation.END_STEP);
-      // Next handle the step hooks list from the flight context
-      handleStepHookList(flightContext.getStepHooks(), contextCopy, HookOperation.END_STEP);
-      flightContext.setStepHooks(null);
-    }
+    // First handle plain step hooks
+    handleHookList(flightContext, HookOperation.END_STEP);
+    // Next handle the step hooks list from the flight context
+    handleStepHookList(flightContext.getStepHooks(), flightContext, HookOperation.END_STEP);
+    flightContext.setStepHooks(null);
   }
 
   public void endFlight(FlightContext flightContext) {
     handleHookList(flightContext, HookOperation.END_FLIGHT);
   }
 
-  private interface HookInterface {
-    void hook(FlightContext context) throws InterruptedException;
-  }
-
   private void handleHookList(FlightContext context, HookOperation operation) {
-    if (stairwayHooks != null) {
-      for (StairwayHook stairwayHook : stairwayHooks) {
-        switch (operation) {
-          case START_FLIGHT:
-            handleHook(makeCopy(context), stairwayHook::startFlight);
-            break;
-
-          case START_STEP:
-            // copy is made in the caller
-            handleHook(context, stairwayHook::startStep);
-            break;
-
-          case END_STEP:
-            // copy is made in the caller
-            handleHook(context, stairwayHook::endStep);
-            break;
-
-          case END_FLIGHT:
-            handleHook(makeCopy(context), stairwayHook::endFlight);
-            break;
-
-          case STATE_TRANSITION:
-            handleHook(makeCopy(context), stairwayHook::stateTransition);
-            break;
-        }
+    for (StairwayHook stairwayHook : stairwayHooks) {
+      try {
+        operation.handleHook(context, stairwayHook);
+      } catch (Exception ex) {
+        logger.warn("Stairway Hook failed with exception", ex);
       }
     }
   }
@@ -96,43 +98,12 @@ public class HookWrapper {
   private void handleStepHookList(List<StepHook> stepHooks, FlightContext context, HookOperation operation) {
     if (stepHooks != null) {
       for (StepHook stepHook : stepHooks) {
-        switch (operation) {
-          case START_STEP:
-            handleHook(context, stepHook::startStep);
-            break;
-
-          case END_STEP:
-            handleHook(context, stepHook::endStep);
-            break;
-
-          case END_FLIGHT:
-          case START_FLIGHT:
-          case STATE_TRANSITION:
-            break;
+        try {
+          operation.handleStepHook(context, stepHook);
+        } catch (Exception ex) {
+          logger.warn("Step Hook failed with exception", ex);
         }
       }
     }
-  }
-
-  private void handleHook(FlightContext context, HookInterface hookMethod) {
-    try {
-      hookMethod.hook(context);
-    } catch (Exception ex) {
-      logger.info("Stairway Hook failed with exception", ex);
-    }
-  }
-
-  private FlightContext makeCopy(FlightContext fc) {
-    FlightContext fc_new =
-        new FlightContext(fc.getInputParameters(), fc.getFlightClassName(), fc.getStepClassNames());
-    fc_new.setDirection(fc.getDirection());
-    fc_new.setFlightId(fc.getFlightId());
-    fc_new.setFlightStatus(fc.getFlightStatus());
-    fc_new.setStairway(fc.getStairway());
-    fc_new.setStepIndex(fc.getStepIndex());
-    fc_new.setResult(fc.getResult());
-    fc_new.setRerun(fc.isRerun());
-    fc_new.setDebugInfo(fc.getDebugInfo());
-    return fc_new;
   }
 }

--- a/src/main/java/bio/terra/stairway/HookWrapper.java
+++ b/src/main/java/bio/terra/stairway/HookWrapper.java
@@ -1,7 +1,6 @@
 package bio.terra.stairway;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -64,7 +63,7 @@ public class HookWrapper {
   }
 
   HookWrapper(List<StairwayHook> stairwayHooks) {
-    this.stairwayHooks = stairwayHooks != null ? stairwayHooks : Collections.emptyList();
+    this.stairwayHooks = stairwayHooks;
   }
 
   void startFlight(FlightContext flightContext) {

--- a/src/main/java/bio/terra/stairway/HookWrapper.java
+++ b/src/main/java/bio/terra/stairway/HookWrapper.java
@@ -80,7 +80,7 @@ public class HookWrapper {
       Optional<StepHook> maybeStepHook = stairwayHook.stepFactory(flightContext);
       maybeStepHook.ifPresent(stepHooks::add);
     }
-    // Then handle an step hooks list from the factory
+    // Then handle any step hooks list from the factory
     handleStepHookList(stepHooks, flightContext, HookOperation.START_STEP);
     flightContext.setStepHooks(stepHooks);
   }

--- a/src/main/java/bio/terra/stairway/RetryRuleFixedInterval.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleFixedInterval.java
@@ -1,9 +1,8 @@
 package bio.terra.stairway;
 
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.TimeUnit;
 
 public class RetryRuleFixedInterval implements RetryRule {
   private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);

--- a/src/main/java/bio/terra/stairway/RetryRuleRandomBackoff.java
+++ b/src/main/java/bio/terra/stairway/RetryRuleRandomBackoff.java
@@ -1,10 +1,9 @@
 package bio.terra.stairway;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RetryRuleRandomBackoff implements RetryRule {
   private static final Logger logger = LoggerFactory.getLogger(RetryRule.class);

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -61,9 +61,9 @@ public class Stairway {
     private ExceptionSerializer exceptionSerializer;
     private String stairwayName;
     private String stairwayClusterName;
-    private List<StairwayHook> stairwayHooks;
+    private List<StairwayHook> stairwayHooks = new ArrayList<>();
     private boolean enableWorkQueue;
-    private Boolean keepFlightLog;
+    private boolean keepFlightLog = true;
     private FlightFactory flightFactory;
     private String workQueueProjectId;
     private String workQueueTopicId;
@@ -190,9 +190,6 @@ public class Stairway {
      * @return this
      */
     public Builder stairwayHook(StairwayHook stairwayHook) {
-      if (this.stairwayHooks == null) {
-        this.stairwayHooks = new ArrayList<>();
-      }
       this.stairwayHooks.add(stairwayHook);
       return this;
     }
@@ -325,7 +322,7 @@ public class Stairway {
     }
 
     this.applicationContext = builder.applicationContext;
-    this.keepFlightLog = (builder.keepFlightLog == null) ? true : builder.keepFlightLog;
+    this.keepFlightLog = builder.keepFlightLog;
     this.quietingDown = new AtomicBoolean();
     this.hookWrapper = new HookWrapper(builder.stairwayHooks);
   }

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -163,7 +163,7 @@ public class Stairway {
      * @return this
      */
     public Builder keepFlightLog(boolean keepFlightLog) {
-      this.keepFlightLog = Boolean.valueOf(keepFlightLog);
+      this.keepFlightLog = keepFlightLog;
       return this;
     }
 

--- a/src/main/java/bio/terra/stairway/StairwayHook.java
+++ b/src/main/java/bio/terra/stairway/StairwayHook.java
@@ -1,11 +1,28 @@
 package bio.terra.stairway;
 
+import java.util.Optional;
+
 public interface StairwayHook {
-  HookAction startFlight(FlightContext context) throws InterruptedException;
+  default HookAction startFlight(FlightContext context) throws InterruptedException {
+    return HookAction.CONTINUE;
+  }
 
-  HookAction startStep(FlightContext context) throws InterruptedException;
+  default HookAction startStep(FlightContext context) throws InterruptedException {
+    return HookAction.CONTINUE;
+  }
 
-  HookAction endFlight(FlightContext context) throws InterruptedException;
+  default HookAction endFlight(FlightContext context) throws InterruptedException {
+    return HookAction.CONTINUE;
+  }
 
-  HookAction endStep(FlightContext context) throws InterruptedException;
+  default HookAction endStep(FlightContext context) throws InterruptedException {
+    return HookAction.CONTINUE;
+  }
+
+  default HookAction stateTransition(FlightContext context) throws InterruptedException {
+    return HookAction.CONTINUE;
+  }
+  default Optional<StepHook> stepFactory(FlightContext context) throws InterruptedException {
+    return Optional.empty();
+  }
 }

--- a/src/main/java/bio/terra/stairway/StairwayHook.java
+++ b/src/main/java/bio/terra/stairway/StairwayHook.java
@@ -22,6 +22,7 @@ public interface StairwayHook {
   default HookAction stateTransition(FlightContext context) throws InterruptedException {
     return HookAction.CONTINUE;
   }
+
   default Optional<StepHook> stepFactory(FlightContext context) throws InterruptedException {
     return Optional.empty();
   }

--- a/src/main/java/bio/terra/stairway/StairwayThreadPool.java
+++ b/src/main/java/bio/terra/stairway/StairwayThreadPool.java
@@ -33,12 +33,12 @@ public class StairwayThreadPool extends ThreadPoolExecutor {
   protected void beforeExecute(Thread t, Runnable r) {
     super.beforeExecute(t, r);
     int active = activeTasks.incrementAndGet();
-    logger.info("before: " + active);
+    logger.debug("before: " + active);
   }
 
   protected void afterExecute(Runnable r, Throwable t) {
     super.afterExecute(r, t);
     int active = activeTasks.decrementAndGet();
-    logger.info("after: " + active);
+    logger.debug("after: " + active);
   }
 }

--- a/src/main/java/bio/terra/stairway/StepHook.java
+++ b/src/main/java/bio/terra/stairway/StepHook.java
@@ -1,0 +1,7 @@
+package bio.terra.stairway;
+
+public interface StepHook {
+  HookAction startStep(FlightContext context) throws InterruptedException;
+
+  HookAction endStep(FlightContext context) throws InterruptedException;
+}

--- a/src/main/resources/stairway/db/SCHEMA.md
+++ b/src/main/resources/stairway/db/SCHEMA.md
@@ -1,0 +1,29 @@
+
+# Stairway Schema Notes
+
+## Using stairwayName as the stairwayId
+In the current state, the `stairwayinstance` table maps from the client-provided stairway name to
+an internal shortUUID. On the one hand, using an internal id provides a uniform shape of ids
+and saves a few bytes of space in the database. However,
+it means that an id to name lookup needs to be done in order to provide logging information.
+
+Instead, we will convert to using the `stairwayName` as the `stairwayId` and eventually remove
+the `stairwayName` column. There may be stairway databases with old ids in them, so we have
+to do this in a two steps.
+
+### Step 1: name and id are identical
+This is upward compatible from the current state. The code continues to lookup by id, so both
+old and new ids will work. This change is being made as part of PF-311.
+
+### Step 2: remove the name column
+After enough time has passed that we think there are no more old id columns, we can take the next
+step. In our current state, we have no guarantees about enough time. We might want to wait until we
+have implemented old flight cleanup and then waited for that time to elapse.
+
+We should remove the column that is easiest. I think that is the `stairwayName` column.
+Removal means:
+* Make `stairwayId` the primary key
+* Drop the `stairwayName` column
+* No name to id lookups are needed anymore, so that interface can be removed
+* Existence and state checking is needed for recovery, but that can be conveyed with a
+boolean, rather than returning the stairwayName (which is also the input param).

--- a/src/test/java/bio/terra/stairway/ScenarioTest.java
+++ b/src/test/java/bio/terra/stairway/ScenarioTest.java
@@ -1,5 +1,15 @@
 package bio.terra.stairway;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import bio.terra.stairway.exception.FlightNotFoundException;
 import bio.terra.stairway.fixtures.MapKey;
 import bio.terra.stairway.fixtures.TestPauseController;
@@ -10,27 +20,16 @@ import bio.terra.stairway.flights.TestFlightRerun;
 import bio.terra.stairway.flights.TestFlightRerunUndo;
 import bio.terra.stairway.flights.TestFlightUndo;
 import bio.terra.stairway.flights.TestFlightWait;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Tag("unit")
 public class ScenarioTest {

--- a/src/test/java/bio/terra/stairway/fixtures/TestHook.java
+++ b/src/test/java/bio/terra/stairway/fixtures/TestHook.java
@@ -1,0 +1,72 @@
+package bio.terra.stairway.fixtures;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.HookAction;
+import bio.terra.stairway.StairwayHook;
+import bio.terra.stairway.StepHook;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestHook implements StairwayHook {
+  private static final Logger logger = LoggerFactory.getLogger(TestHook.class);
+  private static final List<String> hookLog =
+      Collections.synchronizedList(new LinkedList<String>());
+
+  private final String hookId;
+
+  public static List<String> getHookLog() {
+    return hookLog;
+  }
+
+  public static void clearHookLog() {
+    hookLog.clear();
+  }
+
+  public TestHook(String hookId) {
+    this.hookId = hookId;
+  }
+
+  public void addHookLog(String log) {
+    hookLog.add(log);
+    logger.info("addHookLog: {}", log);
+  }
+
+  @Override
+  public HookAction startFlight(FlightContext context) throws InterruptedException {
+    addHookLog(hookId + ":startFlight");
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction startStep(FlightContext context) throws InterruptedException {
+    addHookLog(hookId + ":startStep");
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction endFlight(FlightContext context) throws InterruptedException {
+    addHookLog(hookId + ":endFlight");
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction endStep(FlightContext context) throws InterruptedException {
+    addHookLog(hookId + ":endStep");
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction stateTransition(FlightContext context) throws InterruptedException {
+    addHookLog(hookId + ":stateTransition:" + context.getFlightStatus().name());
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public Optional<StepHook> stepFactory(FlightContext context) throws InterruptedException {
+    return Optional.of(new TestStepHook(hookId, this));
+  }
+}

--- a/src/test/java/bio/terra/stairway/fixtures/TestStepHook.java
+++ b/src/test/java/bio/terra/stairway/fixtures/TestStepHook.java
@@ -1,0 +1,28 @@
+package bio.terra.stairway.fixtures;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.HookAction;
+import bio.terra.stairway.StepHook;
+
+public class TestStepHook implements StepHook {
+
+  private final String hookId;
+  private final TestHook testHook;
+
+  TestStepHook(String hookId, TestHook testHook) {
+    this.hookId = hookId;
+    this.testHook = testHook;
+  }
+
+  @Override
+  public HookAction startStep(FlightContext context) throws InterruptedException {
+    testHook.addHookLog(hookId + ":stepHook:startStep");
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction endStep(FlightContext context) throws InterruptedException {
+    testHook.addHookLog(hookId + ":stepHook:endStep");
+    return HookAction.CONTINUE;
+  }
+}

--- a/src/test/java/bio/terra/stairway/fixtures/TestUtil.java
+++ b/src/test/java/bio/terra/stairway/fixtures/TestUtil.java
@@ -1,9 +1,5 @@
 package bio.terra.stairway.fixtures;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.stairway.ShortUUID;
@@ -14,22 +10,27 @@ import bio.terra.stairway.exception.MigrateException;
 import bio.terra.stairway.exception.QueueException;
 import bio.terra.stairway.exception.StairwayException;
 import bio.terra.stairway.exception.StairwayExecutionException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.sql.DataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class TestUtil {
   private static final Logger logger = LoggerFactory.getLogger(TestUtil.class);
 
   private TestUtil() {}
 
-  public static final Integer intValue = 22;
+  public static final int intValue = 22;
   public static final String strValue = "testing 1 2 3";
-  public static final Double dubValue = Math.PI;
+  public static final double dubValue = Math.PI;
   public static final String errString = "Something bad happened";
   public static final String flightId = "aaa111";
   public static final String ikey = "ikey";
@@ -112,7 +113,7 @@ public final class TestUtil {
 
     for (int i = 0; i < hooks; i++) {
       int hookId = i + 1;
-      TestHook hook = new TestHook(Integer.toString(hookId));
+      TestHook hook = new TestHook(String.valueOf(hookId));
       builder.stairwayHook(hook);
     }
     TestHook.clearHookLog();


### PR DESCRIPTION
The hook enhancements added in this PR are described here [Enhanced Hook Interface](https://docs.google.com/document/d/19CNrhoUbb5-vQFMyScgQTLwpMzl0GQDbiivAunxP18o/edit?pli=1&resourcekey=0-4JNqmHGPilkAyWAo2RmvIg).

Previously, Stairway minted its own unique ID for a Stairway instance. This makes logging in hooks problematic, because you cannot access the mapping from the ID to the Stairway instance. In this PR, I made the unique ID identical to the Stairway instance name. The instance name must already be unique, so there is no semantic difference. The result is that logging can include the Stairway instance name provided by the Stairway caller.

This PR also changes the logging on Stairway retries. Most logging is moved into the RetryRule subclasses and is made more informative. This addresses the confusing logging where Stairway logs "I'm retrying" and the RetryRule quietly says "no you are not".


I think most of the code is fairly obvious. One piece that deserves some explanation is the change to create a FlightContext during recovery. On recovery, we only update the flight row, so do not need the full FlightContext. The only reason to create the FlightContext is for state transition logging. Creating it costs an additional two queries in the database. My judgment was that getting detailed state transition logging was worth the cost. Further, the extra work is only during recovery - typically when a pod is starting up - and not during normal operation.
