### PR TITLE
Use the BroadBot service account to perfom version bumps on master

### DIFF
--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: "Bump the tag to a new version"
         uses: databiosphere/github-actions/actions/bumper@v0.0.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: master,develop
           VERSION_FILE_PATH: build.gradle


### PR DESCRIPTION
Pushing to protected branches as the GitHub actions user is not supported: https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/29

So, let's try using our BroadBot service account instead. I've added the account's PAT as a repo secret and updated repo settings to allow it to push to the develop branch.
