### PR TITLE
[PF-438]: Skip serialize FlighDebugInfo when it does not exist before.   

### DIFF
--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -1,20 +1,21 @@
 package bio.terra.stairway;
 
-import static bio.terra.stairway.FlightStatus.READY;
-import static bio.terra.stairway.FlightStatus.READY_TO_RESTART;
-import static bio.terra.stairway.FlightStatus.WAITING;
-
 import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.stairway.exception.StairwayExecutionException;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import static bio.terra.stairway.FlightStatus.READY;
+import static bio.terra.stairway.FlightStatus.READY_TO_RESTART;
+import static bio.terra.stairway.FlightStatus.WAITING;
 
 /**
  * Manage the atomic execution of a series of Steps This base class has the mechanisms for executing

--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -1,21 +1,20 @@
 package bio.terra.stairway;
 
+import static bio.terra.stairway.FlightStatus.READY;
+import static bio.terra.stairway.FlightStatus.READY_TO_RESTART;
+import static bio.terra.stairway.FlightStatus.WAITING;
+
 import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.stairway.exception.StairwayExecutionException;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-
-import static bio.terra.stairway.FlightStatus.READY;
-import static bio.terra.stairway.FlightStatus.READY_TO_RESTART;
-import static bio.terra.stairway.FlightStatus.WAITING;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manage the atomic execution of a series of Steps This base class has the mechanisms for executing

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -696,8 +696,10 @@ class FlightDao {
     FlightDebugInfo debugInfo = null;
     try {
       debugInfo =
-          FlightDebugInfo.getObjectMapper()
-              .readValue(rs.getString("debug_info"), FlightDebugInfo.class);
+          rs.getString("debug_info") == null
+              ? null
+              : FlightDebugInfo.getObjectMapper()
+                  .readValue(rs.getString("debug_info"), FlightDebugInfo.class);
     } catch (JsonProcessingException e) {
       throw new DatabaseOperationException(e);
     }


### PR DESCRIPTION
Buffer service failed start after upgrade to 0.0.36.  Seems that version introduce the FlightDebugInfo which does not exist in Buffer's existing flights before:

The exception is: 

```
java.lang.IllegalArgumentException: argument "content" is null
at com.fasterxml.jackson.databind.ObjectMapper._assertNotNull (ObjectMapper.java:4693)
at com.fasterxml.jackson.databind.ObjectMapper.readValue (ObjectMapper.java:3401)
at bio.terra.stairway.FlightDao.makeFlightContext (FlightDao.java:700)
at bio.terra.stairway.FlightDao.disownRecovery (FlightDao.java:421)
at bio.terra.stairway.Stairway.recoverAndStart (Stairway.java:393)
at bio.terra.buffer.service.stairway.StairwayComponent.initialize (StairwayComponent.java:73)
at bio.terra.buffer.app.StartupInitializer.initialize (StartupInitializer.java:34)
at bio.terra.buffer.app.configuration.ApplicationConfiguration.lambda$postSetupInitialization$0 (ApplicationConfiguration.java:47)
at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons (DefaultListableBeanFactory.java:910)
at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization (AbstractApplicationContext.java:879)
```