### PR TITLE
PF-316 provide a test fixture for checking FlightMap serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 plugins {
     id 'java-library'
+    id 'java-test-fixtures'
     id 'maven-publish'
     id 'com.jfrog.artifactory' version '4.13.0'
     id 'com.diffplug.gradle.spotless' version '3.27.2'
@@ -17,7 +18,8 @@ plugins {
 }
 
 group 'bio.terra'
-version '0.0.41-SNAPSHOT'
+// DO NOT SUBMIT
+version '0.1.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
 // TODO: there may be a better way to supply these values than envvars.
@@ -37,6 +39,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,6 @@ plugins {
 }
 
 group 'bio.terra'
-// DO NOT SUBMIT
-version '0.1.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
 // TODO: there may be a better way to supply these values than envvars.
@@ -39,7 +37,6 @@ gradle.taskGraph.whenReady { taskGraph ->
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 dependencies {

--- a/src/test/java/bio/terra/stairway/FlightMapTestUtilsTest.java
+++ b/src/test/java/bio/terra/stairway/FlightMapTestUtilsTest.java
@@ -1,0 +1,29 @@
+package bio.terra.stairway;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.stairway.fixtures.FlightsTestPojo;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Test our own test fixtures {@link FlightMapTestUtils}. */
+@Tag("unit")
+public class FlightMapTestUtilsTest {
+  enum MyEnum {
+    FOO,
+  }
+
+  @Test
+  public void serializeAndDeserialize() {
+    FlightMapTestUtils.serializeAndDeserialize("foo");
+    FlightMapTestUtils.serializeAndDeserialize(42);
+    FlightMapTestUtils.serializeAndDeserialize(new FlightsTestPojo().anint(42).astring("foo"));
+
+    assertThrows(
+        ClassCastException.class,
+        () -> FlightMapTestUtils.serializeAndDeserialize(UUID.randomUUID()));
+    assertThrows(
+        ClassCastException.class, () -> FlightMapTestUtils.serializeAndDeserialize(MyEnum.FOO));
+  }
+}

--- a/src/testFixtures/java/bio.terra.stairway/FlightMapTestUtils.java
+++ b/src/testFixtures/java/bio.terra.stairway/FlightMapTestUtils.java
@@ -1,0 +1,26 @@
+package bio.terra.stairway;
+
+/** Utilities for testing with {@link bio.terra.stairway.FlightMap}. */
+public class FlightMapTestUtils {
+  private FlightMapTestUtils() {}
+
+  /**
+   * Tries to serialize and deserialize the object as JSON and a {@link FlightInput} with {@link
+   * FlightMap#put(String, Object)} and {@link FlightMap#get(String, Class)}.
+   *
+   * <p>This is useful for unit testing that arbitrary classes are supported with {@link FlightMap}
+   * serialization.
+   */
+  public static void serializeAndDeserialize(Object object) {
+    String key = "objectKey";
+    FlightMap flightMap = new FlightMap();
+    flightMap.put(key, object);
+
+    FlightMap fromJson = new FlightMap();
+    fromJson.fromJson(flightMap.toJson());
+    fromJson.get(key, object.getClass());
+
+    FlightMap fromInputs = new FlightMap(flightMap.makeFlightInputList());
+    fromInputs.get(key, object.getClass());
+  }
+}

--- a/src/testFixtures/java/bio.terra.stairway/FlightMapTestUtils.java
+++ b/src/testFixtures/java/bio.terra.stairway/FlightMapTestUtils.java
@@ -8,6 +8,8 @@ public class FlightMapTestUtils {
    * Tries to serialize and deserialize the object as JSON and a {@link FlightInput} with {@link
    * FlightMap#put(String, Object)} and {@link FlightMap#get(String, Class)}.
    *
+   * <p>{@link FlightMap} will throw if there's an issue with the serialize/deserialize.
+   *
    * <p>This is useful for unit testing that arbitrary classes are supported with {@link FlightMap}
    * serialization.
    */


### PR DESCRIPTION
This is useful for helping clients determine what they can safely put in a FlightMap.
Example usage: https://github.com/DataBiosphere/terra-workspace-manager/pull/282