### PR TITLE
PF-479 Fatally fail flights that cannot be recovered instead of aborting startup

### DIFF
--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -912,7 +912,16 @@ public class Stairway {
         // recovery to continue.
         logger.error(String.format("Unable to recover flight id %s", flightId), e);
         // Mark the flight as having fatally failed so it does not stay un-recovered forever.
-        flightDao.fatalFail(flightId, e);
+        try {
+          flightDao.fatalFail(flightId, e);
+        } catch (Exception fatalFailException) {
+          // Failed to mark the flight as FATAL. Give up on this flight for now and proceed.
+          logger.error(
+              String.format(
+                  "Unable to fatal fail the flight that was unable to recover. "
+                      + "The flight is still READY. Flight id %s".format(flightId)),
+              fatalFailException);
+        }
       }
     }
   }

--- a/src/test/java/bio/terra/stairway/flights/TestFlightRecoveryUnrecoverableInput.java
+++ b/src/test/java/bio/terra/stairway/flights/TestFlightRecoveryUnrecoverableInput.java
@@ -1,0 +1,26 @@
+package bio.terra.stairway.flights;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import java.util.UUID;
+
+/** A {@link Flight} that tries to get input from a FlightMap that can't be recovered. */
+public class TestFlightRecoveryUnrecoverableInput extends Flight {
+  public static String INPUT_KEY = "bad input";
+
+  public TestFlightRecoveryUnrecoverableInput(
+      FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+    // UUID can't be serialized as an input. This will throw on a deserialized FlightMap, but not on
+    // FlightMap put/get.
+    inputParameters.get(INPUT_KEY, UUID.class);
+    // Step 1 - increment
+    addStep(new TestStepIncrement());
+
+    // Step 2 - stop - allow for failure
+    addStep(new TestStepPause());
+
+    // Step 3 - increment
+    addStep(new TestStepIncrement());
+  }
+}

--- a/src/test/java/bio/terra/stairway/flights/TestFlightRecoveryUnrecoverableWorkingMap.java
+++ b/src/test/java/bio/terra/stairway/flights/TestFlightRecoveryUnrecoverableWorkingMap.java
@@ -1,0 +1,57 @@
+package bio.terra.stairway.flights;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+/** A {@link Flight} that puts data in a working FlightMap that can't be recovered. */
+public class TestFlightRecoveryUnrecoverableWorkingMap extends Flight {
+
+  public TestFlightRecoveryUnrecoverableWorkingMap(
+      FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+    // Step 1 - increment
+    addStep(new TestStepIncrement());
+
+    // Step 2 - put unrecoverable value in the working map.
+    addStep(new PutUnrecoverableValueStep());
+
+    // Step 3 - stop - allow for failure
+    addStep(new TestStepPause());
+
+    // Step 4 - increment
+    addStep(new TestStepIncrement());
+  }
+
+  /* Helper class to put a value in the working map that cannot be deserialized. */
+  public static class PutUnrecoverableValueStep implements Step {
+
+    @Override
+    public StepResult doStep(FlightContext context) {
+      context.getWorkingMap().put("unrecoverable class", new PrivateConstructor("bar"));
+      return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) {
+      return StepResult.getStepResultSuccess();
+    }
+  }
+  /**
+   * The FlightMap serializer is able to serialize but not deserialize this class with a private
+   * constructor.
+   */
+  private static final class PrivateConstructor {
+    private final String foo;
+
+    private PrivateConstructor(String foo) {
+      this.foo = foo;
+    }
+
+    public String getFoo() {
+      return foo;
+    }
+  }
+}


### PR DESCRIPTION
Stairway can fail to deserialize the json of the FlightMap input and working maps. When this happens during flight recovery at start up time, Stairway fails to initialize. This can cause an entire service to be unable to start up if any Flight cannot be recovered. It's better to fatally fail the (hopefully few) unrecoverable flights than prevent the entier service from starting up.

Fatally failing the unrecoverable flights allows clients to move on, as they're not stuck polling for an operation that may never be resolved. This opts to fail fast rather than hope that a newer binary version will be able to handle the previously unrecoverable flight.

Added a test case that covers both the input map and the working map not being deserializable, which covers a couple of the examples from PF-479. The other example was explicitly addressed in PF-438.