### PR TITLE
PF-382 - Add flight developer guide; rearrange other documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,41 @@
+# Developing Stairway
+
+## Branching and Versioning
+The initial design of Stairway branches was that we would use two main branches in github.
+
+The **master** branch ws intended to be used for distributing code
+for other components to consume for alpha, staging, and production. It is published to the `libs-release-local`
+repository inside of artifactory. It always has simple semantic version numbers: _major_._minor_._patch_
+
+The **develop** branch is used for developing code. The results need to be published in order to properly test
+Stairway, should not be used for any production purposes. Is published to the `libs-snapshot-local` repository 
+inside of artifactory. It has a semantic version number and the word snapshot:  _major_._minor_._patch_-SNAPSHOT
+
+The current practice is that we are releasing from the **develop** branch and that is
+being consumed by other components. As things stabilize, we will have to decide if we want
+to continue with direct release or move to indirect release.
+
+## Testing
+
+The Stairway project has unit tests. Running the unit tests requires some configuration:
+1. Install and run a local version of Postgres; for example,  [Postgres App for Mac](https://postgresapp.com/)
+2. Create a test database for Stairway testing. An example SQL script can be found in
+`test/resources/create-stairwaylib-db.sql`
+3. Set environment variables used by the tests to find the database. The default values
+match the values in the sql file above:
+    - STAIRWAY_USERNAME - default is `stairwayuser`
+    - STAIRWAY_PASSWORD - default is `stairwaypw`
+    - STAIRWAY_URI - default is `jdbc:postgresql://127.0.0.1:5432/stairwaylib`
+4. Run the tests. For example, `./gradlew test`    
+
+## Deploying to Artifactory
+
+For Broad-Verily development, you can publish the stairway library to Broad's Artifactory instance
+using the artifactoryPublish task. For that to work, define the following environment variables:
+- ARTIFACTORY_USER
+- ARTIFACTORY_PASSWORD
+
+## Future Enhancements
+
+Right now, the collection of future work is held in a Jira instance run by the Broad and
+is not publicly available.

--- a/FLIGHT_DEVELOPER_GUIDE.md
+++ b/FLIGHT_DEVELOPER_GUIDE.md
@@ -1,0 +1,442 @@
+# Stairway Flight Developer Guide
+
+Date | Status | Notes
+-----|--------|------
+2021-04-14 | Created | First draft
+
+This document provides guidance on how to write Stairway flights. It assumes you are
+familiar with the concepts of Stairway from the README.md
+
+The Stairway implementation is based on the concept of _saga transactions_. It uses
+principles familiar in the world of database systems, but perhaps unfamiliar to
+programmers with different backgrounds. The transactional approach - that the work of a
+flight is either all successfully completed or is all cleaned up - is what makes Stairway
+useful. It provides a structure for building more reliable software. It also requires a
+particular way of programming to make it work.
+
+
+## Table of Contents
+
+ 1. [Logging](#Logging)
+ 1. [Using the Working Map](#workingmap)
+    1. [Persisting at Step Boundaries](#persistatstep)
+    1. [Persisting on Transition from Doing to Undoing](#persistatundo)
+    1. [Working Map Best Practices](#workingmapbest)
+ 1. [Idempotent Steps](#idempotentsteps)
+    1. [Database Transactions](#databasetransactions)
+    1. [Existence Checking](#existencechecking]
+ 1. [Retrying Steps in a Flight](#retrying)
+    1. [Retry Object State and Reuse](#retryreuse)
+    1. [How to Retry](#retryhow)
+    1. [Retry After Restart](#retryafterrestart)
+ 1. [Flight Construction](#flightconstruction)
+    1. [Constructors Should...](#constructorsshould)
+    1. [Constructors Should NOT...](#constructorsshouldnot)
+    1. [Spring Patterns](#springpatterns)
+ 1. [Dismal Failures](#dismalfailures)
+ 1. [Using FlightDebugInfo](#flightdebuginfo)
+    1. [Restart Every Step](#restarteverystep)
+    1. [Fail at Specific Steps](#failsteps)
+
+The ToC is manually maintained. Apologies in advance...
+
+## Logging <a name="logging"></a>
+
+Stairway provides failure recovery by writing state into a SQL database. The database,
+possibly shared across a cluster of cooperating Stairway instances, provides the
+persistent record of a flight.
+
+The Stairway database is written to:
+ * When the flight is initially submitted
+ * At the end of each step of the flight
+ * During flight state changes (more on that later)
+
+When a step is restarted after a failure, Stairway **guarantees** that the flight
+state is exactly what it was when the step originally started.
+
+## Using the Working Map <a name="workingmap"></a>
+
+Every executing flight has a working map. It is a `Map<String, Object>` that allows steps
+to save state and communicate that state to later steps in the flight. It is important to
+understand when the working map is written back to the database. Simply putting something
+into the map does not put it in the database.
+
+### Persisting at Step Boudaries <a name="persistatstep"></a>
+
+The first **key principle** of the working map is that it is persisted at step
+boundaries. To do otherwise would violate the guarantee that a step starts with a
+consistent initial state across failure/recovery.
+
+The table below shows the state of the key "key" in the 
+
+Time | Step | Operation | In memory "key" | Database "key" | Notes
+-----|------|-----------|-----------------|----------------|-------
+ t0 | 0 | start step | null | null | nothing stored yet
+ t1 | 0 | `put("key", "foo")` | "foo" | null | in-memory working map set
+ t2 | 0 | end step | "foo" | "foo" | step state logged to database
+ t3 | 1 | start step | "foo" | "foo" |
+ t4 | 1 | `put("key", "bar")` | "bar" | "foo" | in-memory state updated
+ t5 | 1 | end step | "bar" | "bar" | step state logged to database
+
+Suppose there is a server failure at time t1.5; that is after the working map is updated,
+but before the step state is logged. When the flight is recovered and the step is
+restarted, the state will be exactly what it was at t0; at the start of step 0.
+
+If there is a server failure at time T2.5, step 0 will be considered complete and
+recovery will start with step 1.
+
+### Persisting on Transition From Doing to Undoing <a name="persistatuno"></a>
+
+The second **key principle** of the working map is that it is persisted when a step
+transitions from going forward (doing) to going backwards (undoing) as the result of an error.
+
+Time | Step | Operation | In memory "key" | Database "key" | Notes
+-----|------|-----------|-----------------|----------------|-------
+ t0 | 0 | start step | null | null | nothing stored yet
+ t1 | 0 | `put("key", "foo")` | "foo" | null | in-memory working map set
+ t2 | 0 | error happens | "foo" | null |
+ t3 | 0 | switch to undo | "foo" | "foo" | step state logged to database
+ t4 | 0 | start undo  | "foo" | "foo" | initial state of undo
+ t5 | 0 | `put("key", "xyz")` | "xyz" | "foo" | in-memory working map set
+ t6 | 0 | end step | "xyz" | "xyz" | step state logged to database
+
+As you can see from the table, the switch from do to undo records state in the Stairway
+database. Clearly it must; on server failure/recovery Stairway has to know that it is
+performing an undo. 
+
+Stairway makes the same guarantee about the state at the start of `undo()` as it does for the
+start of `do()`: the initial state will be the same even if there are server failures and
+recovery.
+
+### Working Map Best Practices <a name="workingmapbest"></a>
+
+A useful rule of thumb for the working map is: only use the working map to communicate
+data to later steps.
+
+Do not try to use the working map to communicate between the `do()`
+and the `undo()` of a step. While technically possible, it is difficult to make it
+reliable across server failure/recover.
+
+
+## Idempotent Steps <a name="idempotentsteps"></a>
+One of the features of Stairway is that it can resume flights after failure. Suppose a
+step in a flight is running and the server process is killed (e.g., the Kubernetes pod is
+deleted) the flight can be recovered. On recovery, the step that was running at the point
+of failure, is restarted.
+
+As a result, the `do()` and `undo()` methods of a step must be written to be
+idempotent; that is, they can be run multiple times and must have the same effect each
+time. Meeting that requirement often uses a different approach than writing a sequential program.
+
+### Database Transactions <a name="databasetransactions"></a>
+A step that consists of a database transaction is simple to write. The underlying database
+system provides the rollback of the transaction in the event of failure. However, it is
+still possible for a database transaction step to fail in the window between when the
+database transaction commits and when Stairway logs the completion of the step.
+
+You still have to make the step idempotent, so you have to handle that condition. Let's
+say you are inserting a new object into the database. This is best done by giving your
+target table a primary key column that is a UUID. Then you can run a sequence of steps
+something like this:
+ 1. Step that generates a random UUID and stores it in the working map; _OR_ hand a random
+ UUID into the flight as an input parameter. If this step is run more than once, it will
+ simply generate a different UUID.
+ 1. Step that runs a database transaction. The database transaction does:
+    1. Read the table to see if a row with the UUID already exists. If so, return
+    success. A previous run of the step inserted that row.
+    1. Insert the row into the table.
+    If this step is run more than once, either the database transaction will have rolled
+    back and the row will be re-inserted, or the database transaction will have committed
+    and the read will detect that the insert already happened successfully.
+
+
+A variation on this approach is for the step to trap the duplicate key exception from the
+database system and consider that a success.
+
+### Existence Checking <a name="existencechecking"></a>
+The database transaction case brings up the general problem of coordinating existence
+checking and idempotent steps. There are a few common pitfalls.
+
+#### Pitfall 1: deleting someone else's object
+Imagine that you want to create a thing named "foo". The thing might be a file, a cloud
+object, a database row, whatever. You write a step like this:
+
+```
+Step: Create a thing
+ do():
+   create "foo"
+ undo():
+   delete "foo"
+```
+But what if "foo" already exists when this step is run? The execution will go:
+ 1. Stairway runs `do()` and call create "foo". That results in a "foo already exists"
+ exception.
+ 1. Stairway catches the exception and decides the flight is failed. It
+ transitions to undoing.
+ 1. Stairway runs `undo()` and calls delete "foo". It deletes the pre-existing object.
+
+#### Pitfall 2: failing when you already succeeded
+
+```
+Step: Create a thing - take 2
+ do():
+   if "foo" exists {
+     write "foo already existed" to the working map
+     throw "foo exists"
+   }
+   create "foo"
+ undo():
+   if the working map does says "foo already existed" {
+     then return success
+   }
+   delete "foo"
+```
+That is better. When Stairway catches the exception and transitions to undoing, it writes
+the flight state, so the working map gets written. The undo can skip the delete. Yay!
+
+The problem is that the `do()` is no longer idempotent. Suppose there is a server failure right
+after the "foo" thing is created, but before Stairway records the step result. On
+recovery, Stairway will rerun the `do()` step. It will say, "foo already existed", and the
+flight will fail.
+
+#### Pitfall 3: concurrent operation
+
+A more reliable way to accomplish the existence check is to do it in a separate step. So
+now you have this pseudo-code:
+```
+Step 1: Check thing existence
+ do():
+   if "foo" exists {
+     error out with "foo already exists"
+   }
+ undo():
+   no action
+
+Step 2: Create thing - we only get to this step if "foo" does not exist
+ do():
+   create "foo" - ignore "foo" already exists error
+ undo():
+   delete "foo"
+```
+This works pretty well, but there is still a problem. Suppose there are two flights
+running in parallel that are both trying to create "foo". They will both make it through
+Step 1 and decide "foo" doesn't exist. Then they will both try to create "foo". One will
+successfully create _their version_ of "foo". The other will get a "foo already
+exists" error, ignore it, and think they have succeeded.
+
+#### A Working Approach
+
+The typical case in our system is that we are creating a cloud resource and recording that
+resource in a database. We can use the database state to address the pitfalls. The general
+approach is:
+ 1. Create or provide as flight input a random UUID
+ 1. Write a row in the database with the UUID and the name. If there is a name
+    collision, we fail in this step and do not try to create anything. If there is a UUID
+    collision, we know that it was this flight that previously wrote the row and we can proceed to the next step.
+    If all concurrent creators check the database first, they will conflict on the name
+    before doing any creating.
+ 1. Create the target object
+ 1. If needed, update the database row to record details of the created object.
+
+These pitfalls are presented in the context of object creation, but they appear in related
+forms in other kinds of operations.
+
+## Retrying Steps in a Flight <a name="retrying"></a>
+
+### Retry Object State and Reuse <a name="retryreuse"></a>
+It is important to understand the scope and state of a RetryRule object and only share
+RetryRules objects where they will work properly. It is safe to re-use the same RetryRule
+object *within* a flight. It is not safe to share the same RetryRule object *between*
+flights.
+
+The reason that you cannot share a RetryRule object between flights is that a RetryRule
+object is stateful: it holds the state of retrying. For example, a rule that retries 3
+times needs to hold a counter for the number of retries that have been done. If that
+object is used across flights, each flight would be updating the number of retries.
+
+The reason that you can share a RetryRule object within a flight is that RetryRules have
+an `initialize()` method that resets the state. The Flight object always initializes the
+RetryRule object at the start of executing the `do()` and `undo()` methods of a Step.
+
+Every step has a RetryRule object associated with it. If the rule is not specified, the
+`RetryRuleNone` is used. RetryRuleNone has no state and does no retries. It always
+returns: "do not retry".
+
+### How to Retry <a name="retryhow"></a>
+There are two ways from with a step to request that the step be retried.
+ 1. Throw an exception that derives from `RetryException`. When flight execution catches
+ that exception, it will attempt a retry.
+ 1. Return a StepResult of `STEP_RESULT_FAILURE_RETRY`.
+
+It is our experience that having the step perform its own exception handling and return
+the explicit `STEP_RESULT_FAILURE_RETRY` is more readable. It also keeps service
+exceptions separate from Stairway exceptions.
+
+Remember that simply requesting a retry and actually retrying are two separate
+things. Requesting retry asks Stairway to check the RetryRule to see if there are any more
+retries left. If the rule says, "no more retries", then the exception returned in the
+StepResult is used as the result exception of the flight.
+
+### Retry After Restart <a name="retryafterrestart"></a>
+Retrying is only in-memory. RetryRule state is not retained across a failure/recovery.
+
+Imagine that Stairway is running a step of a flight that uses a retry rule. The rule will
+try 10 times and then give up. Stairway has retried 9 times and then the server fails.
+When the flight is recovered, the step will be restarted and the retry rule counter will
+start at 0 once again.
+
+## Flight Construction <a name="flightconstruction"></a>
+
+The Stairway caller never constructs a Flight object. When you call Stairway to run a flight,
+you provide the input parameters and the class name. Stairway does the actual
+construction. That is because Stairway must be able to re-construct the flight after a
+failure/recovery from the data stored in the Stairway database.
+
+### Constructors Should... <a name="constructorsshould"></a>
+
+Your flight constructor code should construct and configure the steps and retry rules for
+the flight. The constructor might include:
+ - adding different steps based on input parameters
+ - extracting input parameters and providing them as constructor parameters to the steps
+
+### Constructors Should NOT... <a name="constructorsshouldnot"></a>
+
+The constructor **should not**:
+ - do database lookups
+ - access external services
+
+There are two reasons for those constraints. First, flight construction is done in
+Stairway on the recovery path. If a flight cannot be reconstructed, Stairway will
+fail to initialize. That can leave your service in a failed state.  
+
+Second, errors in flight construction can cause the flight to be marked as a dismal
+failure. It is better to keep the construction simpler and do the work within steps where
+you have control over the error handling, retrying and recovery.
+
+### Spring Patterns <a name="springpatterns"></a>
+
+Stairway does not use Spring, but it can be used by services that use Spring.
+
+When you construct a Stairway object, you can provide it with an _application
+context_. It is an `Object` that Stairway passes into flight constructors so they can fill in
+information about their service. It is easily confused with the Spring
+`ApplicationContext` object, but they are not the same thing.
+
+In our experience using Stairway and Spring, the typical use of the Stairway _application
+context_ has been to give flights access to injected (`@Autowired`) singleton
+objects. There are two styles in use described in the next two sections.
+
+#### Stairway Application Context set to Spring Application Context
+
+Suppose you have an autowired class called` FooService`. How can you resolve FooService in
+your flight?
+
+You can set the Stairway application context to be the Spring Application Context like this:
+```java
+@Autowired
+ApplicationContext applicationContext; // Spring application context
+
+Stairway.newBuilder(
+  .applicationContext(applicationContext)
+  ...
+  ).build();
+```
+
+Then your flight constructors need code like this:
+```java
+public YourFlight(FlightMap inputParameters, Object applicationContext) {
+  super(inputParameters, applicationContext);
+
+  ApplicationContext springAppContext = (ApplicationContext)applicationContext;
+  FooService fooService = springAppContext.getBean(FooService.class);
+}
+```
+
+#### Resolve Beans in a "Bean Bag"
+
+An alternative to pulling beans from the Spring application context is to make a so-called
+"Bean Bag" class that resolves the beans and provides getters for use in flight
+constructors. The bean bag is used as the application context. It goes like this:
+
+Set up the bean bag class:
+
+```java
+@Component
+public class BeanBag {
+  private final FooService fooService;
+
+  @Autowired
+  public BeanBag(FooService fooService) {
+    this.fooService = fooService;
+  }
+
+  public FooService getFooService() {
+    return fooService;
+  }
+}
+```
+
+Use the bean bag class as the application context:
+
+```java
+@Autowired
+BeanBag beanBag;
+
+Stairway.newBuilder(
+  .applicationContext(beanBag)
+  ...
+  ).build();
+```
+
+Then your flight constructors look like this:
+
+```java
+  public YourFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+  BeanBag beanBag = (BeanBag)applicationContext;
+  FooService fooService = beanBag.getFooService();
+```
+
+## Dismal Failures <a name="dismalfailures"></a>
+
+Stairway uses the term _dismal failure_ to refer to a flight that has an error and then
+fails to successfully undo. It is the case where the saga transaction is not
+all-or-nothing. This is a serious issue, because the system is left in an unintended,
+potentially corrupt state. It probably requires human intervention to repair the problem.
+
+When this happens, Stairway writes a log message including the text
+`DISMAL FAILURE` that can be used for alerting.
+
+In our experience, there are two main causes of dismal failures:
+ 1. Expired retries
+ 1. Untested undo paths
+
+## Using FlightDebugInfo <a name="flightdebuginfo"></a>
+
+Stairway provides some help test flights. In a test environment, you can pass a
+`FlightDebugInfo` object in when you submit your flight. There are two types of behavior
+you can request.
+
+### Restart Every Step  <a name="restarteverystep"></a>
+
+You can request that Stairway restart your flight at each step boundary. That tests
+several things:
+ * Your flight is not depending on any in-memory object state
+ * Your flight is not holding transient external state
+ * Your flight object can be reconstituted from the Stairway database
+
+Restarting each step does not change the flow of your flight. It will make it a bit slower
+as the flight object is reconstructed.
+
+### Fail at Specific Steps <a name="failsteps"></a>
+
+You can request that Stairway force a failure at any step boundary. This is a useful way
+to exercise the undo path. You specify the failure`StepStatus` you want to return, so you
+can test retry as well as failures that cause undo.
+
+Note that this testing **only** happens at step boundaries, it does not exercise some of
+the more complex cases where the partial execution of a step is either not idempotent or
+causes a failure during undo. Step-specific fault insertion is one way to exercise
+those cases, but it it not built into Stairway.
+

--- a/OUT_OF_DATE_DOCUMENTATION.md
+++ b/OUT_OF_DATE_DOCUMENTATION.md
@@ -1,0 +1,98 @@
+## Details
+### Stairway Startup
+There are three steps to starting up a Stairway instance in your application, described in the next
+sections.
+
+#### Stairway Object Construction
+Use the Stairway.Builder to create a Stairway object. There are a number of parameters you can set to control
+how Stairway functions. You can check the javadoc for most. The ones that affect Stairway startup are:
+- stairwayClusterName - the name of a group of Stairway instances running in a Kubernetes cluster. This name
+is used to find or create a shared work queue for the instances. In a standalone environment, you can allow the
+name to default to a unique random name. 
+- stairwayName - the name of this particular Stairway among the instance running. In Kubernetes, assuming a pod
+contains exactly one Stairway instance, it is handy to use the pod name as the stairwayName. The important property
+is that it be unique among instances. If you don't supply a name, a random one is provided. It may be 
+- projectId - if you supply a projectId, then Stairway will find or create a work 
+queue in that GCP project. (Other clouds to be named later.) Otherwise, there will be no work queue.
+
+The object construction itself just records the inputs. It does not take action on them until the next step.
+That behavior works better in frameworks like Spring where all of the components get created and wired before
+the application starts running.
+
+#### Stairway Initialization
+Stairway initialization sets up the connection to the database. If run in a cluster, all Stairway instances
+must share one database in order to share the state of flights.
+
+The Stairway initialization method provides two booleans that are useful in controlling the database:
+- migrateUpgrade - if true, Stairway performs a liquibase migration on its database.
+- forceCleanStart - if true, Stairway empties the database and the work queue. That is not useful in a
+production system, but handy for test environments.
+
+Stairway initialization allocates internal resources, like thread pools, and the shared work queue.
+
+The last step of initialization is to collect a list of the names of Stairway instances currently recorded in the
+database. Those are returned as the result of the call. Note that this newly created instance is *not* added
+to the list. If the same name is on the list, it should be recovered as described next.
+
+#### Stairway Recover and Start
+Recover-and-start accepts a list of obsolete Stairway instances that should be recovered. It is up to the application
+to determine which instances are obsolete. In the standalone case, all instances found should be recovered.
+
+In the Kubernetes cluster case, the application needs to check if any of the currently recorded instances are running
+in other pods or if they are no longer active. By using pod name for Stairway name, it is easy to match the
+result of a pod list with the recorded instance list returned from initialization.  
+
+Stairway recover-and-start performs recovery on the obsolete instances. It then records this new instance
+and starts accepting flights from the Stairway API and from the Work Queue, if enabled.
+
+### Execution Model
+Stairway provides a set of library calls for flight submission, status check, and waiting for completion.
+These calls all run on the calling thread.
+
+
+_LIES and MORE LIES - this needs to be rewritten_
+
+The application provides a thread pool to Stairway on construction. The application to decide the thread
+allocation model. When a flight is submitted, it is run using a thread from the provided pool.
+That may mean that the flight will queue until a thread is available from the pool. The flight runs
+each step on its thread. Stairway does not provide infrastructure for parallelism within a flight. 
+Of course, a Step can do what it pleases.
+
+### Database 
+Each Stairway instance needs a separate database for managing its flights. If the application instance fails,
+If the application instance fails, we expect that a replacement instance will be launched with the same
+Stairway parameters and will perform recovery of its flights. By partitioning the work this way, we
+minimize contention in the database and have an easy rule for who is supposed to recover a given flight.
+It does not require any global state maintenance within Stairway.
+
+## Submission
+The code for a flight is a class that is an extension to the Flight base class. That Flight subclass
+must supply a constructor that accepts the input parameters as a `FlightMap` map of key-value pairs. The
+constructor creates the list of steps. Each step is an implementation of the Step interface.
+The input parameters can guide the construction of that list.
+
+The Stairway library performs the actual construction of the `Flight` subclass. That is necessary,
+because the Stairway library needs to be able to reconstruct the flight during recovery as well.
+A flight constructor must build exactly the same set of steps when given the same input parameters.
+
+The Stairway library is called to start a flight. It is called with the Class object of flight and
+the input parameters. The submit code locates the constructor and calls it with the input parameters.
+Stairway code writes the information about the flight to the database and schedules the flight to run
+on the thread pool.
+
+The client provides the flight id for a submission. Stairway requires that the flight ids be unique
+within the scope of one Stairway object. Stairway provides a default id generator that generates
+UUID-based ids.
+
+The caller uses the flight id to poll for status or wait on completion of the flight. The flight id is
+also used to collect the resulting working map.
+
+### Exception Handling
+There are two styles of exception handling you can use.
+- handle your own: use try-catch blocks in your code and explicitly return a `StepResult` object from your step.
+The `StepResult` is one of success, failure, or retry.
+- rely on Stairway to handle exceptions.
+
+Stairway maintains a try-catch block around the execution of a Step method. If the exception is derived from
+Stairway's `RetryException`, then we will treat it as if you had returned a `STEP_RESULT_FAILURE_RETRY`. Otherwise,
+it is treated as if you had returned a `STEP_RESULT_FAILURE_FATAL`. 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,39 @@
 # Stairway
-Stairway is a library that provides a framework for running "saga" transactions. 
-The goal is to make a sequence of operations, often over disparate resources,
-run as a transaction; either complete successfully or make no change. A typical
-example in our environment would be an operation where we maintain metadata about
+Stairway is a library that provides a framework for running _saga transactions_. Saga
+transactions, introduced by Hector Garcia-Molina in 1987, use _compensating operations_ to
+rollback the transaction rather than having an service that intermediates activity so is
+able to perform the rollback. The goal is to make a sequence of operations, often over disparate resources,
+run as a transaction; either complete successfully or make no change.
+
+A typical example in our environment is an operation where we maintain metadata about
 an object via a write to a SQL database and create several cloud-platform objects
 to instantiate that object. If any of those operations fail, we want to clean up so
 the state is as if the operation had never occurred.
 
 Stairway provides a way for you to organize your code so that such operations are:
-<ul>
-<li>Atomic - they either happen or don't happen. If something goes wrong, the operation
-undone.</li>
-<li>Recoverable - a failure of the service or system does not lose state. When the
-system recovers, the operation can proceed or rollback.</li>
-</ul>
+ * **Atomic** - they either happen or don't happen. If something goes wrong, the operation undone.
+ * **Recoverable** - a failure of the service or system does not lose state. When the system recovers, the operation can proceed or rollback.
+
+Stairway does not provide as strong a transaction guarantee as a database system. Most database systems are able to
+provide:
+ * **Isolation** -  one transaction runs as if it is the only transaction running
+ * **Consistenty** - a transaction sees a consistent state of the underlying data
+
+Stairway cannot intermediate access to underlying data and objects, so it cannot control
+the view of those objects in the course of running the saga transaction.
 
 With Stairway, you still have to write code with some care to make sure that it results
 in idempotent behavior. The benefit is that Stairway provides a common idiom, and handles
 persistent bookkeeping, retrying, logging, and recovery after failure.
 
+## References
+For more information on developing flights in Stairway see: [Stairway Flight Developer Guide](FLIGHT_DEVELOPER_GUIDE.md)
+
+For information on developing Stairway see [Developing Stairway](DEVELOPMENT.md)
+
 ## Overview
+This section provides an overview of Stairway concepts.
+
 ### Flights and Steps
 A `Step` contains a single operation. It provides two methods: `do` and `undo`. The `do` method performs the
 operation. The `undo` method removes the effects of the operation. Your step classes are derived from the `Step`
@@ -40,8 +54,7 @@ was launched
 the flight.
 
 Working parameters are the way that steps communicate with each other or remember information needed to undo
-their work. For example, a step allocating a resource might store the resource id in a parameter. The undo
-code would lookup that id in the working parameters and use it to delete the resource.
+their work.
 
 When the flight completes, the working parameters can be retrieved. The result of the flight can be gathered
 from the working parameters. For example, TDR uses the convention that Flights store their results in an object
@@ -76,174 +89,3 @@ You can create your own derivation of the `RetryRule` class and implement your o
 Stairway is designed to provide atomic operations for one instance of one service. It does not coordinate any
 global or cross-service state. Therefore, it is up to the application or service to implement concurrency control on 
 its objects.
-
-For example, in TDR data ingest jobs have a `load-tag`. The tag can be reused serially to rerun failed ingests.
-Only one ingest job is allowed to use a `load-tag` at a time. Tag concurrency is controlled by "locking" the
-tag at the start of an ingest job and "unlocking" it at the end. The lock is locked and unlocked by
-updating a row in a database. The row contains two columns:
-- boolean - locked or unlocked
-- flightId - UUID of the flight that has the lock
-The flightId is needed to make sure that a second call by the same flight to lock the tag (as would happen
-during recovery) will notice that this flight already holds the lock and will not generate a CONFLICT error.
-
-The `do` method in first step of a data ingest flight locks the tag. The `undo`
-method unlocks the tag. The `do` method of the last step of the ingest flight unlocks the tag.
-Because Stairway guarantees recovery, the Flight author knows that the resource will be locked during the
-flight and unlocked regardless of whether the flight succeeds or fails.
-
-### Examples
-Terra Data Repository (Jade) uses Stairway and has many examples of its use.
-See [jade-data-repo](https://github.com/DataBiosphere/jade-data-repo)
-
-## Details
-### Stairway Startup
-There are three steps to starting up a Stairway instance in your application, described in the next
-sections.
-
-#### Stairway Object Construction
-Use the Stairway.Builder to create a Stairway object. There are a number of parameters you can set to control
-how Stairway functions. You can check the javadoc for most. The ones that affect Stairway startup are:
-- stairwayClusterName - the name of a group of Stairway instances running in a Kubernetes cluster. This name
-is used to find or create a shared work queue for the instances. In a standalone environment, you can allow the
-name to default to a unique random name. 
-- stairwayName - the name of this particular Stairway among the instance running. In Kubernetes, assuming a pod
-contains exactly one Stairway instance, it is handy to use the pod name as the stairwayName. The important property
-is that it be unique among instances. If you don't supply a name, a random one is provided. It may be 
-- projectId - if you supply a projectId, then Stairway will find or create a work 
-queue in that GCP project. (Other clouds to be named later.) Otherwise, there will be no work queue.
-
-The object construction itself just records the inputs. It does not take action on them until the next step.
-That behavior works better in frameworks like Spring where all of the components get created and wired before
-the application starts running.
-
-#### Stairway Initialization
-Stairway initialization sets up the connection to the database. If run in a cluster, all Stairway instances
-must share one database in order to share the state of flights.
-
-The Stairway initialization method provides two booleans that are useful in controlling the database:
-- migrateUpgrade - if true, Stairway performs a liquibase migration on its database.
-- forceCleanStart - if true, Stairway empties the database and the work queue. That is not useful in a
-production system, but handy for test environments.
-
-Stairway initialization allocates internal resources, like thread pools, and the shared work queue.
-
-The last step of initialization is to collect a list of the names of Stairway instances currently recorded in the
-database. Those are returned as the result of the call. Note that this newly created instance is *not* added
-to the list. If the same name is on the list, it should be recovered as described next.
-
-#### Stairway Recover and Start
-Recover-and-start accepts a list of obsolete Stairway instances that should be recovered. It is up to the application
-to determine which instances are obsolete. In the standalone case, all instances found should be recovered.
-
-In the Kubernetes cluster case, the application needs to check if any of the currently recorded instances are running
-in other pods or if they are no longer active. By using pod name for Stairway name, it is easy to match the
-result of a pod list with the recorded instance list returned from initialization.  
-
-Stairway recover-and-start performs recovery on the obsolete instances. It then records this new instance
-and starts accepting flights from the Stairway API and from the Work Queue, if enabled.
-
-### Execution Model
-Stairway provides a set of library calls for flight submission, status check, and waiting for completion.
-These calls all run on the calling thread.
-
-
-_LIES and MORE LIES - this needs to be rewritten_
-
-The application provides a thread pool to Stairway on construction. The application to decide the thread
-allocation model. When a flight is submitted, it is run using a thread from the provided pool.
-That may mean that the flight will queue until a thread is available from the pool. The flight runs
-each step on its thread. Stairway does not provide infrastructure for parallelism within a flight. 
-Of course, a Step can do what it pleases.
-
-### Database 
-Each Stairway instance needs a separate database for managing its flights. If the application instance fails,
-If the application instance fails, we expect that a replacement instance will be launched with the same
-Stairway parameters and will perform recovery of its flights. By partitioning the work this way, we
-minimize contention in the database and have an easy rule for who is supposed to recover a given flight.
-It does not require any global state maintenance within Stairway.
-
-## Submission
-The code for a flight is a class that is an extension to the Flight base class. That Flight subclass
-must supply a constructor that accepts the input parameters as a `FlightMap` map of key-value pairs. The
-constructor creates the list of steps. Each step is an implementation of the Step interface.
-The input parameters can guide the construction of that list.
-
-The Stairway library performs the actual construction of the `Flight` subclass. That is necessary,
-because the Stairway library needs to be able to reconstruct the flight during recovery as well.
-A flight constructor must build exactly the same set of steps when given the same input parameters.
-
-The Stairway library is called to start a flight. It is called with the Class object of flight and
-the input parameters. The submit code locates the constructor and calls it with the input parameters.
-Stairway code writes the information about the flight to the database and schedules the flight to run
-on the thread pool.
-
-The client provides the flight id for a submission. Stairway requires that the flight ids be unique
-within the scope of one Stairway object. Stairway provides a default id generator that generates
-UUID-based ids.
-
-The caller uses the flight id to poll for status or wait on completion of the flight. The flight id is
-also used to collect the resulting working map.
-
-### Exception Handling
-There are two styles of exception handling you can use.
-- handle your own: use try-catch blocks in your code and explicitly return a `StepResult` object from your step.
-The `StepResult` is one of success, failure, or retry.
-- rely on Stairway to handle exceptions.
-
-Stairway maintains a try-catch block around the execution of a Step method. If the exception is derived from
-Stairway's `RetryException`, then we will treat it as if you had returned a `STEP_RESULT_FAILURE_RETRY`. Otherwise,
-it is treated as if you had returned a `STEP_RESULT_FAILURE_FATAL`. 
-
-# Developing Stairway
-
-## Branching and Versioning
-There are two branches of interest in the stairway github. The **master** branch is used for distributing code
-for other components to consume for alpha, staging, and production. It is published to the `libs-release-local`
-repository inside of artifactory. It always has simple semantic version numbers: _major_._minor_._patch_
-
-The **develop** branch is used for developing code. The results need to be published in order to properly test
-Stairway, should not be used for any production purposes. Is published to the `libs-snapshot-local` repository 
-inside of artifactory. It has a semantic version number and the word snapshot:  _major_._minor_._patch_-SNAPSHOT
-
-The versions are related by convention. The develop version is typically a minor or major increment ahead
-of the master version.
-
-## Testing
-
-The Stairway project has unit tests. Running the unit tests requires some configuration:
-1. Install and run a local version of Postgres; for example,  [Postgres App for Mac](https://postgresapp.com/)
-2. Create a test database for Stairway testing. An example SQL script can be found in
-`test/resources/create-stairwaylib-db.sql`
-3. Set environment variables used by the tests to find the database. The default values
-match the values in the sql file above:
-    - STAIRWAY_USERNAME - default is `stairwayuser`
-    - STAIRWAY_PASSWORD - default is `stairwaypw`
-    - STAIRWAY_URI - default is `jdbc:postgresql://127.0.0.1:5432/stairwaylib`
-4. Run the tests. For example, `./gradlew test`    
-
-## Deploying to Artifactory
-
-For Broad-Verily development, you can publish the stairway library to Broad's Artifactory instance
-using the artifactoryPublish task. For that to work, define the following environment variables:
-- ARTIFACTORY_USER
-- ARTIFACTORY_PASSWORD
-
-## Future Enhancements
-
-Here is a list of planned enhancements for Stairway:
-- scale out and scale back - it is simple to scale out, adding new Stairway instances. There is no convenient
-support in Stairway for scaling back; that is taking an instance out of service. We need to add a way to
-quiesce the service so all current operations complete and no new ones are started. That would allow an
-application instance to come to a quiet point where it could be taken out of service.
-- read-only flights - enable the (re-)use of steps, the thread pool and retries, but does no logging.
-The motivation is to use Stairway as a consistent way of running async REST API requests, without the
-logging overhead.
-- fault insertion - it is difficult to test the atomicity, idempotency and recoverability of steps. The idea is
-to provide hooks to allow a failure at any step boundary, and targeted recovery, to ensure that those properties
-are achieved.
-- multiple thread pools - Stairway runs with on thread pool with one set of properties. It _might_ be useful to
-have different flavors of pools and submit flights to specific pools.
-
-These enhancements are discussed in
-[Stairway Enhancements](https://docs.google.com/document/d/1BMo6e8uJb1fLpQdbeAujenV2YurNGajBzDwey-bVa_4/edit?pli=1#heading=h.mwr27m9insmm)
-  


### PR DESCRIPTION
I wrote a flight developer guide. That needs a review.

I split the README up:
- Removed the obsolete details section into OUT_OF_DATE_DOCUMENTATION.md. I will replace it with the md formatted version of the Stairway design doc, but that needs work before I convert it.
- Moved the Stairway developer stuff into DEVELOPMENT.md