### PR TITLE
PF-694 Add FlightDebugInfo support for failing after the last step.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,8 @@ plugins {
 }
 
 group 'bio.terra'
-version '0.0.43-SNAPSHOT'
+// do not submit
+version '0.0.44-SNAPSHOT'
 sourceCompatibility = 1.8
 
 // TODO: there may be a better way to supply these values than envvars.
@@ -37,6 +38,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,7 @@ plugins {
 }
 
 group 'bio.terra'
-// do not submit
-version '0.0.44-SNAPSHOT'
+version '0.0.43-SNAPSHOT'
 sourceCompatibility = 1.8
 
 // TODO: there may be a better way to supply these values than envvars.
@@ -38,7 +37,6 @@ gradle.taskGraph.whenReady { taskGraph ->
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 

--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -281,7 +281,6 @@ public class Flight implements Runnable {
           result = debugStatusReplacement(result);
         } else {
           result = currentStep.step.undoStep(context());
-          result = debugStatusReplacement(result);
         }
       } catch (InterruptedException ex) {
         // Interrupted exception - we assume this means that the thread pool is shutting down and
@@ -351,7 +350,6 @@ public class Flight implements Runnable {
     // failed here, then insert a failure. We do this right after the step completes but
     // before the flight logs it so that we can look for dangerous UNDOs.
     if (debugInfo.getFailAtSteps() != null
-        && context().isDoing()
         && debugInfo.getFailAtSteps().containsKey(context().getStepIndex())
         && !debugStepsFailed.contains(context().getStepIndex())) {
       StepStatus failStatus = debugInfo.getFailAtSteps().get(context().getStepIndex());
@@ -364,9 +362,7 @@ public class Flight implements Runnable {
     }
     // If we are in debug mode for failing at the last step, and this is the last step, insert a
     // failure.
-    if (debugInfo.getLastStepFailure()
-        && context().isDoing()
-        && context().getStepIndex() == steps.size() - 1) {
+    if (debugInfo.getLastStepFailure() && context().getStepIndex() == steps.size() - 1) {
       logger.info("Failed for debug mode last step failure.");
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);
     }

--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -287,10 +287,21 @@ public class Flight implements Runnable {
               && context().isDoing()
               && context().getDebugInfo().getFailAtSteps().containsKey(context().getStepIndex())
               && !debugStepsFailed.contains(context().getStepIndex())) {
-            result =
-                new StepResult(
-                    this.context().getDebugInfo().getFailAtSteps().get(context().getStepIndex()));
+            StepStatus failStatus =
+                this.context().getDebugInfo().getFailAtSteps().get(context().getStepIndex());
+            logger.info(
+                "Failed for debug mode fail step at step {} with result {}",
+                context().getStepIndex(),
+                failStatus);
+            result = new StepResult(failStatus);
             debugStepsFailed.add(context().getStepIndex());
+          } else if (context().getDebugInfo() != null
+              && context().getDebugInfo().getLastStepFailure()
+              && context().getStepIndex() == steps.size() - 1) {
+            // If we are in debug mode for failing at the last step and this is the last step,
+            // insert a failure.
+            logger.info("Failed for debug mode last step failure.");
+            result = new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);
           }
         } else {
           result = currentStep.step.undoStep(context());

--- a/src/main/java/bio/terra/stairway/FlightDebugInfo.java
+++ b/src/main/java/bio/terra/stairway/FlightDebugInfo.java
@@ -1,6 +1,7 @@
 package bio.terra.stairway;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 
@@ -10,7 +11,8 @@ import java.util.Map;
  */
 public class FlightDebugInfo {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   private boolean restartEachStep; // if true - restart the flight at each step
   // If true, make the flight's last do Step result in STEP_RESULT_FATAL_FAILURE after it executes.
   // This is useful for checking correct UNDO behavior for a whole flight.

--- a/src/main/java/bio/terra/stairway/FlightDebugInfo.java
+++ b/src/main/java/bio/terra/stairway/FlightDebugInfo.java
@@ -12,6 +12,9 @@ public class FlightDebugInfo {
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private boolean restartEachStep; // if true - restart the flight at each step
+  // If true, make the flight's last do Step result in STEP_RESULT_FATAL_FAILURE after it executes.
+  // This is useful for checking correct UNDO behavior for a whole flight.
+  private boolean lastStepFailure;
 
   // Each entry in the map is the index at which we should insert a failure. Note that retryable
   // failures should only be inserted on steps that can be safely retried.
@@ -20,10 +23,16 @@ public class FlightDebugInfo {
   // Use a builder so it is easy to add new fields
   public static class Builder {
     private boolean restartEachStep;
+    private boolean lastStepFailure;
     private Map<Integer, StepStatus> failAtSteps;
 
     public Builder restartEachStep(boolean restart) {
       this.restartEachStep = restart;
+      return this;
+    }
+
+    public Builder lastStepFailure(boolean lastStepFailure) {
+      this.lastStepFailure = lastStepFailure;
       return this;
     }
 
@@ -49,6 +58,7 @@ public class FlightDebugInfo {
   public FlightDebugInfo(FlightDebugInfo.Builder builder) {
     this.restartEachStep = builder.restartEachStep;
     this.failAtSteps = builder.failAtSteps;
+    this.lastStepFailure = builder.lastStepFailure;
   }
 
   public FlightDebugInfo() {
@@ -61,6 +71,14 @@ public class FlightDebugInfo {
 
   public void setRestartEachStep(boolean restart) {
     this.restartEachStep = restart;
+  }
+
+  public boolean getLastStepFailure() {
+    return lastStepFailure;
+  }
+
+  public void setLastStepFailure(boolean lastStepFailure) {
+    this.lastStepFailure = lastStepFailure;
   }
 
   public Map<Integer, StepStatus> getFailAtSteps() {


### PR DESCRIPTION
Extend the FlightDebugInfo in Stairway to allow it to be easy to test undoing a flight by setting a failure after the last do step executes.

By adding a field, existing versions of Stairway will not be able to deserialize FlightDebugInfo's serialized by this and newer versions going forward: they will be [unable to make a FlightContext](https://github.com/DataBiosphere/stairway/blob/cdaed8050bc3a4c1729f1d7d6f9bcd9987307c76/src/main/java/bio/terra/stairway/FlightDao.java#L578-L586). Older versions serializations will be able to be deserialized by this version, as ObjectMapper's FAIL_ON_UNKNOWN_PROPERTIES defaults to false. this is a backwards incompatible change for FlightDebugInfo serialization.
Set `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` to make this not the case in the future.