### PR TITLE
PF-699 Add FlightDebugInfo support for failing do & undo by Step class name

### DIFF
--- a/src/main/java/bio/terra/stairway/FlightDebugInfo.java
+++ b/src/main/java/bio/terra/stairway/FlightDebugInfo.java
@@ -79,7 +79,7 @@ public class FlightDebugInfo {
     return new FlightDebugInfo.Builder();
   }
 
-  public FlightDebugInfo(Builder builder) {
+  public FlightDebugInfo(FlightDebugInfo.Builder builder) {
     this.restartEachStep = builder.restartEachStep;
     this.failAtSteps = builder.failAtSteps;
     this.lastStepFailure = builder.lastStepFailure;

--- a/src/main/java/bio/terra/stairway/FlightDebugInfo.java
+++ b/src/main/java/bio/terra/stairway/FlightDebugInfo.java
@@ -22,11 +22,23 @@ public class FlightDebugInfo {
   // failures should only be inserted on steps that can be safely retried.
   private Map<Integer, StepStatus> failAtSteps;
 
+  // Map from Step class name, e.g. MyStep.class.getName(), to the failure to insert on do. Note
+  // that retryable failures should only be inserted on step's with do operations that can be safely
+  // retried.
+  private Map<String, StepStatus> doStepFailures;
+
+  // Map from Step class name, e.g. MyStep.class.getName(), to the failure to insert on undo. Note
+  // that retryable failures should only be inserted on step's with undo operations that can be
+  // safely retried.
+  private Map<String, StepStatus> undoStepFailures;
+
   // Use a builder so it is easy to add new fields
   public static class Builder {
     private boolean restartEachStep;
     private boolean lastStepFailure;
     private Map<Integer, StepStatus> failAtSteps;
+    private Map<String, StepStatus> doStepFailures;
+    private Map<String, StepStatus> undoStepFailures;
 
     public Builder restartEachStep(boolean restart) {
       this.restartEachStep = restart;
@@ -40,6 +52,16 @@ public class FlightDebugInfo {
 
     public Builder failAtSteps(Map<Integer, StepStatus> failures) {
       this.failAtSteps = failures;
+      return this;
+    }
+
+    public Builder doStepFailures(Map<String, StepStatus> doStepFailures) {
+      this.doStepFailures = doStepFailures;
+      return this;
+    }
+
+    public Builder undoStepFailures(Map<String, StepStatus> undoStepFailures) {
+      this.undoStepFailures = undoStepFailures;
       return this;
     }
 
@@ -57,10 +79,12 @@ public class FlightDebugInfo {
     return new FlightDebugInfo.Builder();
   }
 
-  public FlightDebugInfo(FlightDebugInfo.Builder builder) {
+  public FlightDebugInfo(Builder builder) {
     this.restartEachStep = builder.restartEachStep;
     this.failAtSteps = builder.failAtSteps;
     this.lastStepFailure = builder.lastStepFailure;
+    this.doStepFailures = builder.doStepFailures;
+    this.undoStepFailures = builder.undoStepFailures;
   }
 
   public FlightDebugInfo() {
@@ -89,6 +113,22 @@ public class FlightDebugInfo {
 
   public void setFailAtSteps(Map<Integer, StepStatus> failures) {
     this.failAtSteps = failures;
+  }
+
+  public Map<String, StepStatus> getDoStepFailures() {
+    return doStepFailures;
+  }
+
+  public void setDoStepFailures(Map<String, StepStatus> doStepFailures) {
+    this.doStepFailures = doStepFailures;
+  }
+
+  public Map<String, StepStatus> getUndoStepFailures() {
+    return undoStepFailures;
+  }
+
+  public void setUndoStepFailures(Map<String, StepStatus> undoStepFailures) {
+    this.undoStepFailures = undoStepFailures;
   }
 
   static ObjectMapper getObjectMapper() {

--- a/src/main/java/bio/terra/stairway/Step.java
+++ b/src/main/java/bio/terra/stairway/Step.java
@@ -42,5 +42,5 @@ public interface Step {
    * @return step result object
    * @throws InterruptedException when the thread pool is being shut down
    */
-  StepResult undoStep(FlightContext context) throws InterruptedException;
+  StepResult undoStep(FlightContext context) throws InterruptedException, RetryException;
 }

--- a/src/main/java/bio/terra/stairway/Step.java
+++ b/src/main/java/bio/terra/stairway/Step.java
@@ -42,5 +42,5 @@ public interface Step {
    * @return step result object
    * @throws InterruptedException when the thread pool is being shut down
    */
-  StepResult undoStep(FlightContext context) throws InterruptedException, RetryException;
+  StepResult undoStep(FlightContext context) throws InterruptedException;
 }


### PR DESCRIPTION
Extend Stairway's FlightDebugInfo to allow changing the status of step's by the Step's class name instead of a step index. Step index could be changed by adding more steps to a Flight, but by using the Step.class class name, it's easier to express what's being tested and fail to compile if a test's step name changes.

Allow the setting failures on both `do` and `undo` for a Step, as it's important to verify that undo operations are also idempotent to avoid dismal failures.

This will not support the same step class name being run multiple times, bu that does not seem to be as useful.