### PR TITLE
[PF-703] Stop writing to flightlog::working_parameters and flight::ou…

### DIFF
--- a/stairway/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightDao.java
@@ -712,9 +712,9 @@ class FlightDao {
             flightContext.setFlightStatus(FlightStatus.valueOf(rsflight.getString("status")));
             flightContext.setStepIndex(rsflight.getInt("step_index"));
 
-            // We may have JSON from output_parameters, a set of working parameters from
-            // flightworking table, neither, or both.  Deletgate the decision of which to use to
-            // FlightMap class.
+            // TODO(PF-917): We may have JSON from working_parameters, a set of parameters from
+            // flightworking table, neither, or both.  For now, delegate the decision of which to
+            // use to FlightMap class.  PF-917 will remove column working_parameters.
 
             final String workingMapJson = rsflight.getString("working_parameters");
 
@@ -889,8 +889,9 @@ class FlightDao {
         flightState.setException(
             exceptionSerializer.deserialize(rs.getString("serialized_exception")));
 
-        // We may have JSON from output_parameters, a set of working parameters from flightworking
-        // table, neither, or both.  Deletgate the decision of which to use to FlightMap class.
+        // TODO(PF-917): We may have JSON from output_parameters, a set of parameters from
+        // flightworking table, neither, or both.  For now, delegate the decision of which to use to
+        // FlightMap class.  PF-917 will remove column output_parameters.
 
         String outputParamsJson = rs.getString("output_parameters");
         final List<FlightInput> workingList = retrieveLatestWorkingParameters(connection, flightId);

--- a/stairway/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightDao.java
@@ -152,9 +152,9 @@ class FlightDao {
     final String sqlInsertFlightLog =
         "INSERT INTO "
             + FLIGHT_LOG_TABLE
-            + "(id, flightid, log_time, working_parameters, step_index, rerun, direction,"
+            + "(id, flightid, log_time, step_index, rerun, direction,"
             + " succeeded, serialized_exception, status)"
-            + " VALUES (:logId, :flightId, CURRENT_TIMESTAMP, :workingMap, :stepIndex, :rerun, :direction,"
+            + " VALUES (:logId, :flightId, CURRENT_TIMESTAMP, :stepIndex, :rerun, :direction,"
             + " :succeeded, :serializedException, :status)";
 
     String serializedException =
@@ -166,11 +166,6 @@ class FlightDao {
       startTransaction(connection);
       statement.setUuid("logId", logId);
       statement.setString("flightId", flightContext.getFlightId());
-
-      // TODO(PF-703): Column working_parameters is being phased out in favor of table
-      // flightworking.  We continue to write the working map here temporarily for backward
-      // compatibility.
-      statement.setString("workingMap", flightContext.getWorkingMap().toJson());
 
       statement.setInt("stepIndex", flightContext.getStepIndex());
       statement.setBoolean("rerun", flightContext.isRerun());
@@ -397,7 +392,6 @@ class FlightDao {
         "UPDATE "
             + FLIGHT_TABLE
             + " SET completed_time = CURRENT_TIMESTAMP,"
-            + " output_parameters = :outputParameters,"
             + " status = :status,"
             + " serialized_exception = :serializedException,"
             + " stairway_id = NULL"
@@ -411,10 +405,6 @@ class FlightDao {
             new NamedParameterPreparedStatement(connection, sqlUpdateFlight)) {
 
       startTransaction(connection);
-
-      // TODO(PF-703): Column output_parameters is being phased out in favor of table flightworking.
-      //  We continue to write the output map here temporarily for backward compatibility.
-      statement.setString("outputParameters", flightContext.getWorkingMap().toJson());
 
       statement.setString("status", flightContext.getFlightStatus().name());
       statement.setString("serializedException", serializedException);
@@ -722,19 +712,16 @@ class FlightDao {
             flightContext.setFlightStatus(FlightStatus.valueOf(rsflight.getString("status")));
             flightContext.setStepIndex(rsflight.getInt("step_index"));
 
-            // TODO(PF-703): In the current transition away from working_parameters column towards
-            // flightworking table we can either have only JSON or both.  Until we've transitioned,
-            // delegate the decision of which to use to the FlightMap class.
+            // We may have JSON from output_parameters, a set of working parameters from
+            // flightworking table, neither, or both.  Deletgate the decision of which to use to
+            // FlightMap class.
 
             final String workingMapJson = rsflight.getString("working_parameters");
 
             final List<FlightInput> workingList =
                 retrieveWorkingParameters(connection, rsflight.getObject("id", UUID.class));
 
-            // If we built a working map from the data, replace the flight context's default working
-            // map with it.
-            FlightMap.create(workingList, workingMapJson)
-                .ifPresent(workingMap -> flightContext.setWorkingMap(workingMap));
+            flightContext.setWorkingMap(FlightMap.create(workingList, workingMapJson));
           }
         }
       }
@@ -902,16 +889,12 @@ class FlightDao {
         flightState.setException(
             exceptionSerializer.deserialize(rs.getString("serialized_exception")));
 
-        // TODO(PF-703): In the current transition away from output_parameters column towards
-        // flightworking table we can either have only JSON or both.  Until we've transitioned,
-        // delegate the decision of which to use to the FlightMap class.
+        // We may have JSON from output_parameters, a set of working parameters from flightworking
+        // table, neither, or both.  Deletgate the decision of which to use to FlightMap class.
 
         String outputParamsJson = rs.getString("output_parameters");
         final List<FlightInput> workingList = retrieveLatestWorkingParameters(connection, flightId);
-
-        // If we were able to build a map from the data, use it to set the result map.
-        FlightMap.create(workingList, outputParamsJson)
-            .ifPresent(flightMap -> flightState.setResultMap(flightMap));
+        flightState.setResultMap(FlightMap.create(workingList, outputParamsJson));
       }
 
       flightStateList.add(flightState);

--- a/stairway/src/main/java/bio/terra/stairway/FlightMap.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightMap.java
@@ -57,6 +57,15 @@ public class FlightMap {
    * {@code List<FlightInput>}, both, or neither at deserialization time. This method is used to
    * generate a FlightMap based on what was contained in the database.
    *
+   * <p>Flights written with:
+   *
+   * <p>* Version < 0.0.50: Only json is valid, inputList is always empty.
+   *
+   * <p>* Version 0.0.50 - 0.0.60: json and inputList both valid and must be consistent with one
+   * another.
+   *
+   * <p>* Version >= 0.0.61: json always null, inputList is always valid (possibly empty).
+   *
    * @param inputList Entries in flightworking for a given Flight log. May be empty if Flight
    *     pre-existed flightworking table, or there are no working parameters.
    * @param json Map of working entries for a given Flight log in JSON. May be NULL.
@@ -106,7 +115,7 @@ public class FlightMap {
     try {
       return getObjectMapper().readValue(value, type);
     } catch (JsonProcessingException ex) {
-      throw new ClassCastException(
+      throw new JsonConversionException(
           "Found value '" + value + "' is not an instance of type " + type.getName());
     }
   }

--- a/stairway/src/main/java/bio/terra/stairway/FlightMap.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightMap.java
@@ -59,12 +59,12 @@ public class FlightMap {
    *
    * <p>Flights written with:
    *
-   * <p>* Version < 0.0.50: Only json is valid, inputList is always empty.
-   *
-   * <p>* Version 0.0.50 - 0.0.60: json and inputList both valid and must be consistent with one
-   * another.
-   *
-   * <p>* Version >= 0.0.61: json always null, inputList is always valid (possibly empty).
+   * <ul>
+   *   <li>Version < 0.0.50: Only json is valid, inputList is always empty.
+   *   <li>Version 0.0.50 - 0.0.60: json and inputList both valid and must be consistent with one
+   *       another.
+   *   <li>Version >= 0.0.61: json always null, inputList is always valid (possibly empty).
+   * </ul>
    *
    * @param inputList Entries in flightworking for a given Flight log. May be empty if Flight
    *     pre-existed flightworking table, or there are no working parameters.
@@ -102,7 +102,7 @@ public class FlightMap {
    * @param key - key to lookup in the hash map
    * @param type - class requested
    * @return null if not found
-   * @throws ClassCastException if found, not deserializable to the requested type
+   * @throws JsonConversionException if found, not deserializable to the requested type
    */
   @Nullable
   public <T> T get(String key, Class<T> type) {
@@ -116,7 +116,7 @@ public class FlightMap {
       return getObjectMapper().readValue(value, type);
     } catch (JsonProcessingException ex) {
       throw new JsonConversionException(
-          "Found value '" + value + "' is not an instance of type " + type.getName());
+          "Failed to deserialize value '" + value + "' from JSON to type " + type.getName(), ex);
     }
   }
 

--- a/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
@@ -146,7 +146,8 @@ public class FlightMapTest {
     Assertions.assertNull(map.get(badKey, NonStaticClass.class));
 
     // Deserializing the wrong type results in ClassCastException.
-    Assertions.assertThrows(ClassCastException.class, () -> map.get(intKey, FlightsTestPojo.class));
+    Assertions.assertThrows(
+        JsonConversionException.class, () -> map.get(intKey, FlightsTestPojo.class));
 
     // Deserializing map from bad JSON throws
     Assertions.assertThrows(

--- a/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
@@ -2,11 +2,9 @@ package bio.terra.stairway;
 
 import bio.terra.stairway.exception.JsonConversionException;
 import bio.terra.stairway.fixtures.FlightsTestPojo;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -38,6 +36,11 @@ public class FlightMapTest {
   private static final String enumKey = "myenum";
   private static final MyEnum enumIn = MyEnum.FOO;
 
+  // JSON created by calling now-removed toJson() method on a FlightMap instance populated by
+  // loadMap() using an older version of code.
+  private static final String jsonMap =
+      "[\"java.util.HashMap\",{\"myenum\":[\"bio.terra.stairway.FlightMapTest$MyEnum\",\"FOO\"],\"myuuid\":[\"java.util.UUID\",\"2e74e380-cccd-48ad-a0ac-e006b3650dbe\"],\"mystring\":\"StringValue\",\"mykey\":3,\"mypojo\":[\"bio.terra.stairway.fixtures.FlightsTestPojo\",{\"astring\":\"mystring\",\"anint\":99}]}]";
+
   private void loadMap(FlightMap outMap) {
     outMap.put(pojoKey, pojoIn);
     outMap.put(intKey, intIn);
@@ -68,8 +71,21 @@ public class FlightMapTest {
 
     // Basic test of put/get
     FlightMap map = new FlightMap();
+    Assertions.assertTrue(map.isEmpty());
     loadMap(map);
+    Assertions.assertFalse(map.isEmpty());
     verifyMap(map);
+
+    FlightMap fromRawMap = new FlightMap();
+    fromRawMap.putRaw(pojoKey, map.getRaw(pojoKey));
+    fromRawMap.putRaw(intKey, map.getRaw(intKey));
+    fromRawMap.putRaw(stringKey, map.getRaw(stringKey));
+    fromRawMap.putRaw(uuidKey, map.getRaw(uuidKey));
+    fromRawMap.putRaw(enumKey, map.getRaw(enumKey));
+    verifyMap(fromRawMap);
+
+    // Test that a non-existent key returns null
+    Assertions.assertNull(map.get("key", Object.class));
 
     // Just making sure this doesn't completely malfunction...
     String output = map.toString();
@@ -93,85 +109,23 @@ public class FlightMapTest {
   }
 
   @Test
-  public void toAndFromJson() {
-    FlightMap outMap = new FlightMap();
-
-    // Test that a non-existent key returns null
-    Assertions.assertNull(outMap.get("key", Object.class));
-
-    loadMap(outMap);
-
-    String json = outMap.toJson();
-    logger.debug("JSON: '{}'", json);
-
-    FlightMap inMap = new FlightMap();
-    inMap.fromJson(json);
-    verifyMap(inMap);
-  }
-
-  @Test
-  public void fromJsonMap() {
-
-    // JSON created by calling toJson() on a map instance populated by loadMap() using an older
-    // version of code.
-    String jsonMap =
-        "[\"java.util.HashMap\",{\"myenum\":[\"bio.terra.stairway.FlightMapTest$MyEnum\",\"FOO\"],\"myuuid\":[\"java.util.UUID\",\"2e74e380-cccd-48ad-a0ac-e006b3650dbe\"],\"mystring\":\"StringValue\",\"mykey\":3,\"mypojo\":[\"bio.terra.stairway.fixtures.FlightsTestPojo\",{\"astring\":\"mystring\",\"anint\":99}]}]";
-
-    logger.debug(" In JSON: {}", jsonMap);
-
-    // Verify that a map created from this JSON contains the expected data.
-    FlightMap map = new FlightMap();
-    map.fromJson(jsonMap);
-    verifyMap(map);
-  }
-
-  @Test
   public void createTest() {
     FlightMap sourceMap = new FlightMap();
     loadMap(sourceMap);
 
     List<FlightInput> list = sourceMap.makeFlightInputList();
-    String json = sourceMap.toJson();
 
-    // Ignore list, use JSON
-    Optional<FlightMap> fromListMap = FlightMap.create(list, json);
-    Assertions.assertTrue(fromListMap.isPresent());
-    verifyMap(fromListMap.get());
+    // Empty list with null JSON, returns empty map
+    FlightMap emptyNullJsonMap = FlightMap.create(new ArrayList<>(), null);
+    Assertions.assertTrue(emptyNullJsonMap.isEmpty());
 
-    // Null JSON returns empty map
-    Optional<FlightMap> nullJsonEmptyListMap = FlightMap.create(new ArrayList<>(), null);
-    Assertions.assertFalse(nullJsonEmptyListMap.isPresent());
+    // Empty list with valid JSON, use JSON
+    FlightMap useJsonMap = FlightMap.create(new ArrayList<>(), jsonMap);
+    verifyMap(useJsonMap);
 
-    // Missing entry logs error, but still has good content
-    List<FlightInput> missingList = new ArrayList<>(list);
-    missingList.remove(missingList.size() - 1);
-    Optional<FlightMap> missingMap = FlightMap.create(missingList, json);
-    Assertions.assertTrue(missingMap.isPresent());
-    verifyMap(missingMap.get());
-    Assertions.assertThrows(
-        RuntimeException.class, () -> missingMap.get().validateAgainst(missingList));
-
-    // Bad key in list logs error, but still has good content
-    List<FlightInput> badKeyList = new ArrayList<>(list);
-    FlightInput badKeyInput = new FlightInput("badkey", "badval");
-    badKeyList.remove(badKeyList.size() - 1);
-    badKeyList.add(badKeyInput);
-    Optional<FlightMap> badListKeyMap = FlightMap.create(badKeyList, json);
-    Assertions.assertTrue(badListKeyMap.isPresent());
-    verifyMap(badListKeyMap.get());
-    Assertions.assertThrows(
-        RuntimeException.class, () -> badListKeyMap.get().validateAgainst(badKeyList));
-
-    // Bad value in list logs error, but still has good content
-    List<FlightInput> badValueList = new ArrayList<>(list);
-    FlightInput badValueInput = new FlightInput(pojoKey, "badval");
-    badValueList.remove(badValueList.size() - 1);
-    badValueList.add(badValueInput);
-    Optional<FlightMap> badListValueMap = FlightMap.create(badValueList, json);
-    Assertions.assertTrue(badListValueMap.isPresent());
-    verifyMap(badListValueMap.get());
-    Assertions.assertThrows(
-        JsonProcessingException.class, () -> badListValueMap.get().validateAgainst(badValueList));
+    // Otherwise use list
+    FlightMap useListMap = FlightMap.create(list, jsonMap);
+    verifyMap(useListMap);
   }
 
   @SuppressFBWarnings(
@@ -183,17 +137,19 @@ public class FlightMapTest {
   @Test
   public void serDesExceptions() {
     FlightMap map = new FlightMap();
+    loadMap(map);
 
     // Serializing an unserializable class results in JsonConversionException.
     final String badKey = "bad";
     NonStaticClass unserializable = new NonStaticClass();
-    map.put(badKey, unserializable);
-    Assertions.assertThrows(JsonConversionException.class, () -> map.toJson());
+    Assertions.assertThrows(JsonConversionException.class, () -> map.put(badKey, unserializable));
+    Assertions.assertNull(map.get(badKey, NonStaticClass.class));
 
     // Deserializing the wrong type results in ClassCastException.
-    Assertions.assertThrows(ClassCastException.class, () -> map.get(badKey, FlightsTestPojo.class));
+    Assertions.assertThrows(ClassCastException.class, () -> map.get(intKey, FlightsTestPojo.class));
 
     // Deserializing map from bad JSON throws
-    Assertions.assertThrows(JsonConversionException.class, () -> map.fromJson("garbage"));
+    Assertions.assertThrows(
+        JsonConversionException.class, () -> FlightMap.create(new ArrayList<>(), "garbage"));
   }
 }

--- a/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
@@ -145,7 +145,7 @@ public class FlightMapTest {
     Assertions.assertThrows(JsonConversionException.class, () -> map.put(badKey, unserializable));
     Assertions.assertNull(map.get(badKey, NonStaticClass.class));
 
-    // Deserializing the wrong type results in ClassCastException.
+    // Deserializing the wrong type results in JsonConversionException.
     Assertions.assertThrows(
         JsonConversionException.class, () -> map.get(intKey, FlightsTestPojo.class));
 


### PR DESCRIPTION
- This PR corresponds to [Phase 2 as described in this document](https://docs.google.com/document/d/1b1VckTBb_V1pCMhoN2GgHnGDR2f8MV2HuwIgDqFc_9M/edit#heading=h.49331srrvaui):
  - Stop writing JSON maps to `flightlog::working_parameters` and `flight::output_parameters columns`, write parameters via `flightworking` table only. 
  - Move serialization/deserialization to `put()`/`get()` time.