### PR TITLE
[PF-785] Fix scoping on subquery when getting latest working parameters.

### DIFF
--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -926,8 +926,8 @@ class FlightDao {
         "SELECT key, value FROM "
             + FLIGHT_WORKING_TABLE
             + " WHERE flightlog_id="
-            + "(SELECT id FROM flightlog WHERE log_time="
-            + "   (SELECT MAX(log_time) FROM flightlog WHERE flightid = :flightId))";
+            + "(SELECT id FROM flightlog WHERE (flightid = :flightId) AND log_time="
+            + "   (SELECT MAX(log_time) FROM flightlog WHERE flightid = :flightId2))";
 
     List<FlightInput> inputList = new ArrayList<>();
 
@@ -935,6 +935,7 @@ class FlightDao {
         new NamedParameterPreparedStatement(connection, sqlSelectInput)) {
 
       statement.setString("flightId", flightId);
+      statement.setString("flightId2", flightId);
       try (ResultSet rs = statement.getPreparedStatement().executeQuery()) {
         while (rs.next()) {
           FlightInput input = new FlightInput(rs.getString("key"), rs.getString("value"));


### PR DESCRIPTION
This query fails:
```
        "SELECT key, value FROM "
            + FLIGHT_WORKING_TABLE
            + " WHERE flightlog_id="
            + "(SELECT id FROM flightlog WHERE log_time="
            + "   (SELECT MAX(log_time) FROM flightlog WHERE flightid = :flightId))";
```
Because `flightlog::id` can be NULL, so multiple rows can be returned from:

`SELECT id FROM flightlog WHERE log_time=`

Fix is to also select on `flightid` here.