### PR TITLE
Add workflow_dispatch trigger to develop version bump.

### DIFF
--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch: {}
 jobs:
   update_image:
     strategy:


### PR DESCRIPTION
I would have liked to make the bump+publish trigger a little more full featured[ like Workspace Manager's](https://github.com/DataBiosphere/terra-workspace-manager/blob/dev/.github/workflows/tag-publish.yml#L30), but this is really a hedge against recent flakiness in GitHub actions.  PF-789 created for future improvements.