### PR TITLE
[PF-827] Fix to validation of flightworking vs flight map

### DIFF
--- a/src/main/java/bio/terra/stairway/FlightMap.java
+++ b/src/main/java/bio/terra/stairway/FlightMap.java
@@ -125,11 +125,13 @@ public class FlightMap {
 
     for (FlightInput input : inputList) {
       final String key = input.getKey();
-      final Object object = map.get(key);
-      if (object == null) {
+      if (!map.containsKey(key)) {
         throw new RuntimeException(String.format("Key '%s' not found in map.", key));
       }
-      getObjectMapper().readValue(input.getValue(), object.getClass());
+      final Object object = map.get(key);
+      if (object != null) {
+        getObjectMapper().readValue(input.getValue(), object.getClass());
+      }
     }
   }
 


### PR DESCRIPTION
The validator was not distinguishing between "key not found" and "key found and value is null".

I verified the fix by changing WSM to build against mavenLocal and running the previously-failing test against the change.
The spurious error was not reported.