### PR TITLE
Add TypeReference<T> Overload and Register Guava Module with ObjectMapper

### DIFF
--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
     // JSON processing
     implementation('com.fasterxml.jackson.core:jackson-databind:2.12.3')
+    implementation('com.fasterxml.jackson.datatype:jackson-datatype-guava:2.12.3')
     implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3')
     implementation('com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.3')
     implementation('com.fasterxml.jackson.module:jackson-module-parameter-names:2.12.3')

--- a/stairway/src/main/java/bio/terra/stairway/FlightMap.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightMap.java
@@ -95,13 +95,26 @@ public class FlightMap {
   }
 
   /**
-   * Return the object from the hash map deserialized to the right type. Throw an exception if the
-   * Object cannot be deserialized to that type.
+   * Returns true if this map contains a mapping of the passed key.
+   *
+   * @param key to look up in the map
+   * @return true if present
+   */
+  boolean containsKey(String key) {
+    return map.containsKey(key);
+  }
+
+  /**
+   * Return the object from the hash map deserialized to the right non-parameterized type. Throw an
+   * exception if the Object cannot be deserialized to that type. For parameterized types, the
+   * {@code TypeReference<T>} overload of this method offers more type safety and should be
+   * preferred.
    *
    * @param <T> - type of class to expect in the hash map
    * @param key - key to lookup in the hash map
    * @param type - class requested
-   * @return null if not found
+   * @return null if not found or if a null value is stored at that key (use method {@code
+   *     containsKey()} to differentiate)
    * @throws JsonConversionException if found, not deserializable to the requested type
    */
   @Nullable
@@ -117,6 +130,38 @@ public class FlightMap {
     } catch (JsonProcessingException ex) {
       throw new JsonConversionException(
           "Failed to deserialize value '" + value + "' from JSON to type " + type.getName(), ex);
+    }
+  }
+
+  /**
+   * Return the object from the hash map deserialized to the right type. Throw an exception if the
+   * Object cannot be deserialized to that type. This overload is preferred when deserializing
+   * parameterized types as it provides stronger type checking at deserialization time.
+   *
+   * @param <T> - type of class to expect in the hash map
+   * @param key - key to lookup in the hash map
+   * @param typeReference - class requested
+   * @return null if not found or if a null value is stored at that key (use method {@code
+   *     containsKey()} to differentiate)
+   * @throws JsonConversionException if found, not deserializable to the requested type
+   */
+  @Nullable
+  public <T> T get(String key, TypeReference<T> typeReference) {
+    String value = map.get(key);
+
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      return getObjectMapper().readValue(value, typeReference);
+    } catch (JsonProcessingException ex) {
+      throw new JsonConversionException(
+          "Failed to deserialize value '"
+              + value
+              + "' from JSON to type "
+              + typeReference.getType().getTypeName(),
+          ex);
     }
   }
 

--- a/stairway/src/main/java/bio/terra/stairway/FlightMap.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightMap.java
@@ -90,7 +90,7 @@ public class FlightMap {
   }
 
   /** Check map for emptiness */
-  boolean isEmpty() {
+  public boolean isEmpty() {
     return map.isEmpty();
   }
 
@@ -100,22 +100,22 @@ public class FlightMap {
    * @param key to look up in the map
    * @return true if present
    */
-  boolean containsKey(String key) {
+  public boolean containsKey(String key) {
     return map.containsKey(key);
   }
 
   /**
-   * Return the object from the hash map deserialized to the right non-parameterized type. Throw an
-   * exception if the Object cannot be deserialized to that type. For parameterized types, the
+   * Return the object from the flight map deserialized to the right non-parameterized type. Throw
+   * an exception if the Object cannot be deserialized to that type. For parameterized types, the
    * {@code TypeReference<T>} overload of this method offers more type safety and should be
    * preferred.
    *
-   * @param <T> - type of class to expect in the hash map
-   * @param key - key to lookup in the hash map
+   * @param <T> - type of class to expect in the flight map
+   * @param key - key to lookup in the flight map
    * @param type - class requested
    * @return null if not found or if a null value is stored at that key (use method {@code
    *     containsKey()} to differentiate)
-   * @throws JsonConversionException if found, not deserializable to the requested type
+   * @throws JsonConversionException if not deserializable to the requested type
    */
   @Nullable
   public <T> T get(String key, Class<T> type) {
@@ -134,16 +134,16 @@ public class FlightMap {
   }
 
   /**
-   * Return the object from the hash map deserialized to the right type. Throw an exception if the
+   * Return the object from the flight map deserialized to the right type. Throw an exception if the
    * Object cannot be deserialized to that type. This overload is preferred when deserializing
    * parameterized types as it provides stronger type checking at deserialization time.
    *
-   * @param <T> - type of class to expect in the hash map
-   * @param key - key to lookup in the hash map
+   * @param <T> - type of class to expect in the flight map
+   * @param key - key to lookup in the flight map
    * @param typeReference - class requested
    * @return null if not found or if a null value is stored at that key (use method {@code
    *     containsKey()} to differentiate)
-   * @throws JsonConversionException if found, not deserializable to the requested type
+   * @throws JsonConversionException if not deserializable to the requested type
    */
   @Nullable
   public <T> T get(String key, TypeReference<T> typeReference) {
@@ -166,9 +166,9 @@ public class FlightMap {
   }
 
   /**
-   * Returns the raw String stored for a given key in the hash map.
+   * Returns the raw String stored for a given key in the flight map.
    *
-   * @param key to lookup in the hash map
+   * @param key to lookup in the flight map
    * @return null if not found
    */
   @Nullable
@@ -177,7 +177,7 @@ public class FlightMap {
   }
 
   /**
-   * Serialize the passed Object to a JSON String and store in the hash map
+   * Serialize the passed Object to a JSON String and store in the flight map
    *
    * @param key to store the data under
    * @param value to serialize and store
@@ -192,7 +192,7 @@ public class FlightMap {
   }
 
   /**
-   * Store a raw String representing a serialized object in the hash map
+   * Store a raw String representing a serialized object in the flight map
    *
    * @param key to store the String under
    * @param rawValue to store

--- a/stairway/src/main/java/bio/terra/stairway/StairwayMapper.java
+++ b/stairway/src/main/java/bio/terra/stairway/StairwayMapper.java
@@ -2,6 +2,7 @@ package bio.terra.stairway;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
@@ -22,6 +23,7 @@ public class StairwayMapper {
               .registerModule(new Jdk8Module())
               .registerModule(new JavaTimeModule())
               .registerModule(new JsonNullableModule())
+              .registerModule(new GuavaModule())
               .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
               // TODO: replace with new method; the problem is we need to be promiscuous, because
               //  Stairway does not control what objects are serialized into the map.

--- a/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
@@ -2,10 +2,13 @@ package bio.terra.stairway;
 
 import bio.terra.stairway.exception.JsonConversionException;
 import bio.terra.stairway.fixtures.FlightsTestPojo;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -32,6 +35,8 @@ public class FlightMapTest {
 
   private enum MyEnum {
     FOO,
+    BAR,
+    BAZ,
   }
 
   private static final String enumKey = "myenum";
@@ -43,28 +48,57 @@ public class FlightMapTest {
       "[\"java.util.HashMap\",{\"myenum\":[\"bio.terra.stairway.FlightMapTest$MyEnum\",\"FOO\"],\"myuuid\":[\"java.util.UUID\",\"2e74e380-cccd-48ad-a0ac-e006b3650dbe\"],\"mystring\":\"StringValue\",\"mykey\":3,\"mypojo\":[\"bio.terra.stairway.fixtures.FlightsTestPojo\",{\"astring\":\"mystring\",\"anint\":99}]}]";
 
   private void loadMap(FlightMap outMap) {
+    Assertions.assertFalse(outMap.containsKey(pojoKey));
     outMap.put(pojoKey, pojoIn);
+
+    Assertions.assertFalse(outMap.containsKey(intKey));
     outMap.put(intKey, intIn);
+
+    Assertions.assertFalse(outMap.containsKey(stringKey));
     outMap.put(stringKey, stringIn);
+
+    Assertions.assertFalse(outMap.containsKey(uuidKey));
     outMap.put(uuidKey, uuidIn);
+
+    Assertions.assertFalse(outMap.containsKey(enumKey));
     outMap.put(enumKey, enumIn);
   }
 
   private void verifyMap(FlightMap inMap) {
+    Assertions.assertTrue(inMap.containsKey(pojoKey));
     FlightsTestPojo pojoOut = inMap.get(pojoKey, FlightsTestPojo.class);
     Assertions.assertEquals(pojoIn, pojoOut);
 
+    pojoOut = inMap.get(pojoKey, new TypeReference<>() {});
+    Assertions.assertEquals(pojoIn, pojoOut);
+
+    Assertions.assertTrue(inMap.containsKey(intKey));
     Integer intOut = inMap.get(intKey, Integer.class);
     Assertions.assertEquals(intIn, intOut);
 
+    intOut = inMap.get(intKey, new TypeReference<>() {});
+    Assertions.assertEquals(intIn, intOut);
+
+    Assertions.assertTrue(inMap.containsKey(stringKey));
     String stringOut = inMap.get(stringKey, String.class);
     Assertions.assertEquals(stringIn, stringOut);
 
+    stringOut = inMap.get(stringKey, new TypeReference<>() {});
+    Assertions.assertEquals(stringIn, stringOut);
+
+    Assertions.assertTrue(inMap.containsKey(uuidKey));
     UUID uuidOut = inMap.get(uuidKey, UUID.class);
     Assertions.assertEquals(uuidIn, uuidOut);
 
+    uuidOut = inMap.get(uuidKey, new TypeReference<>() {});
+    Assertions.assertEquals(uuidIn, uuidOut);
+
+    Assertions.assertTrue(inMap.containsKey(enumKey));
     MyEnum enumOut = inMap.get(enumKey, MyEnum.class);
     Assertions.assertEquals(enumOut, enumIn);
+
+    enumOut = inMap.get(enumKey, new TypeReference<>() {});
+    Assertions.assertEquals(enumIn, enumOut);
   }
 
   @Test
@@ -165,5 +199,37 @@ public class FlightMapTest {
 
     ImmutableList<Integer> immutableListOut = flightMap.get(key, ImmutableList.class);
     Assertions.assertEquals(immutableListIn, immutableListOut);
+  }
+
+  @Test
+  public void typeRef() {
+    FlightMap flightMap = new FlightMap();
+    final String key = "key";
+
+    Map<MyEnum, FlightsTestPojo> testMapIn = new HashMap<>();
+    testMapIn.put(MyEnum.FOO, new FlightsTestPojo().anint(1).astring("first"));
+    testMapIn.put(MyEnum.BAR, new FlightsTestPojo().anint(2).astring("second"));
+    testMapIn.put(MyEnum.BAZ, new FlightsTestPojo().anint(3).astring("third"));
+    flightMap.put(key, testMapIn);
+
+    // This overload does not support parameterized types; any type that is not castable from String
+    // will cause failures upon use of the Map.
+    Map<MyEnum, FlightsTestPojo> testMapOut = flightMap.get(key, Map.class);
+    Assertions.assertNotEquals(testMapIn, testMapOut);
+
+    // This overload supports parameterized types and will correctly deserialize the parameter
+    // types.
+    testMapOut = flightMap.get(key, new TypeReference<>() {});
+    Assertions.assertEquals(testMapIn, testMapOut);
+
+    // This will silently allow us to deserialize the wrong type, but using the map will
+    // subsequently fail.
+    Map<UUID, FlightsTestPojo> badMapOut = flightMap.get(key, Map.class);
+
+    // This version will throw an exception if deserialization of the requested type is not
+    // possible.
+    Assertions.assertThrows(
+        JsonConversionException.class,
+        () -> flightMap.get(key, new TypeReference<Map<UUID, FlightsTestPojo>>() {}));
   }
 }

--- a/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/FlightMapTest.java
@@ -2,6 +2,7 @@ package bio.terra.stairway;
 
 import bio.terra.stairway.exception.JsonConversionException;
 import bio.terra.stairway.fixtures.FlightsTestPojo;
+import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
@@ -152,5 +153,17 @@ public class FlightMapTest {
     // Deserializing map from bad JSON throws
     Assertions.assertThrows(
         JsonConversionException.class, () -> FlightMap.create(new ArrayList<>(), "garbage"));
+  }
+
+  @Test
+  public void guavaTypes() {
+    FlightMap flightMap = new FlightMap();
+
+    final String key = "immutableList";
+    ImmutableList<Integer> immutableListIn = ImmutableList.of(1, 2, 3, 4);
+    flightMap.put(key, immutableListIn);
+
+    ImmutableList<Integer> immutableListOut = flightMap.get(key, ImmutableList.class);
+    Assertions.assertEquals(immutableListIn, immutableListOut);
   }
 }


### PR DESCRIPTION
So... turns out that the `TypeReference<T>` overload was needed after all, where Workspace Manager is storing `Map<enum, T>` in several places that break once we are no longer caching object references in the map...

Also adds the ability to ser/des Guava containers (also done in WS Manager, maybe only in tests...)