### PR TITLE
[PF-988] queue fixes for TCL/WSM integration

### DIFF
--- a/stairway-gcp/src/main/java/bio/terra/stairway/gcp/GcpQueueUtils.java
+++ b/stairway-gcp/src/main/java/bio/terra/stairway/gcp/GcpQueueUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.stairway.gcp;
 
 import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
@@ -53,6 +54,9 @@ public class GcpQueueUtils {
 
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create(topicAdminSettings)) {
       topicAdminClient.createTopic(topicName);
+      logger.debug("Created topic: " + topicId);
+    } catch (AlreadyExistsException ex) {
+      logger.debug("Topic already exists: " + topicId);
     }
   }
 
@@ -112,6 +116,9 @@ public class GcpQueueUtils {
               .build();
 
       subscriptionAdminClient.createSubscription(request);
+      logger.debug("Created subscription: " + subscriptionId);
+    } catch (AlreadyExistsException ex) {
+      logger.debug("Subscription already exists: " + subscriptionId);
     }
   }
 

--- a/stairway/src/main/java/bio/terra/stairway/Stairway.java
+++ b/stairway/src/main/java/bio/terra/stairway/Stairway.java
@@ -77,8 +77,9 @@ public interface Stairway {
    * notices a pod failure.
    *
    * @param stairwayName name of a stairway instance to recover
+   * @throws InterruptedException interruption during recovery
    */
-  void recoverStairway(String stairwayName);
+  void recoverStairway(String stairwayName) throws InterruptedException;
 
   /**
    * Graceful shutdown: instruct stairway to stop executing flights. When running flights hit a step

--- a/stairway/src/main/java/bio/terra/stairway/Stairway.java
+++ b/stairway/src/main/java/bio/terra/stairway/Stairway.java
@@ -71,6 +71,16 @@ public interface Stairway {
           StairwayExecutionException;
 
   /**
+   * Recover any orphaned flights from a particular Stairway instance.
+   * This method can be called when a server using Stairway discovers that
+   * another Stairway instance has failed. For example, when a Kubernetes listener
+   * notices a pod failure.
+   *
+   * @param stairwayName name of a stairway instance to recover
+   */
+  void recoverStairway(String stairwayName);
+
+  /**
    * Graceful shutdown: instruct stairway to stop executing flights. When running flights hit a step
    * boundary they will yield. No new flights are able to start. Then this thread waits for
    * termination of the thread pool; basically, just exposing the awaitTermination parameters.

--- a/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
@@ -194,6 +194,24 @@ public class StairwayImpl implements Stairway {
     queueManager.start();
   }
 
+  /**
+   * Recover any orphaned flights from a particular Stairway instance.
+   * This method can be called when a server using Stairway discovers that
+   * another Stairway instance has failed. For example, when a Kubernetes listener
+   * notices a pod failure.
+   *
+   * @param stairwayName name of a stairway instance to recover
+   * @throws DatabaseOperationException database access error
+   * @throws InterruptedException interruption during recovery
+   * @throws StairwayExecutionException stairway error
+   */
+  public void recoverStairway(String stairwayName)
+      throws DatabaseOperationException, InterruptedException, StairwayExecutionException {
+    String stairwayId = stairwayInstanceDao.lookupId(stairwayName);
+    flightDao.disownRecovery(stairwayId);
+    recoverReady();
+  }
+
   private void configureThreadPools() {
     threadPool =
         new StairwayThreadPool(

--- a/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
@@ -201,12 +201,9 @@ public class StairwayImpl implements Stairway {
    * notices a pod failure.
    *
    * @param stairwayName name of a stairway instance to recover
-   * @throws DatabaseOperationException database access error
    * @throws InterruptedException interruption during recovery
-   * @throws StairwayExecutionException stairway error
    */
-  public void recoverStairway(String stairwayName)
-      throws DatabaseOperationException, InterruptedException, StairwayExecutionException {
+  public void recoverStairway(String stairwayName) throws InterruptedException {
     String stairwayId = stairwayInstanceDao.lookupId(stairwayName);
     flightDao.disownRecovery(stairwayId);
     recoverReady();

--- a/stairway/src/test/java/bio/terra/stairway/fixtures/TestStairwayBuilder.java
+++ b/stairway/src/test/java/bio/terra/stairway/fixtures/TestStairwayBuilder.java
@@ -11,6 +11,7 @@ import bio.terra.stairway.QueueInterface;
 import bio.terra.stairway.ShortUUID;
 import bio.terra.stairway.Stairway;
 import bio.terra.stairway.StairwayBuilder;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
@@ -29,6 +30,7 @@ public class TestStairwayBuilder {
   private boolean continuing;
   private int testHookCount;
   private boolean doRecoveryCheck;
+  private boolean existingStairwaysAreAlive;
   private String flightId;
 
   /** Set stairway name. If not present, a random name is generated */
@@ -77,6 +79,11 @@ public class TestStairwayBuilder {
    */
   public TestStairwayBuilder flightId(String flightId) {
     this.flightId = flightId;
+    return this;
+  }
+
+  public TestStairwayBuilder existingStairwaysAreAlive(boolean existingStairwaysAreAlive) {
+    this.existingStairwaysAreAlive = existingStairwaysAreAlive;
     return this;
   }
 
@@ -138,6 +145,11 @@ public class TestStairwayBuilder {
       }
     }
 
+    // If we are treating existing stairways as running, then don't pass the recorded stairways
+    // into recoverAndStart for recovery.
+    if (existingStairwaysAreAlive) {
+      recordedStairways = Collections.emptyList();
+    }
     stairway.recoverAndStart(recordedStairways);
     return stairway;
   }

--- a/stairway/src/test/java/bio/terra/stairway/impl/RecoveryTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/RecoveryTest.java
@@ -189,4 +189,50 @@ public class RecoveryTest {
     Integer value = result.getResultMap().get().get("value", Integer.class);
     assertThat(value, is(equalTo(12)));
   }
+
+  @Test
+  public void recoverOneTest() throws Exception {
+    final String stairway1Name = "recoverOneTestOne";
+    final String stairway2Name = "recoverOneTestTwo";
+
+    // The idea here is to start two stairways, run a flight on one that pauses.
+    // Then from the second, use the recoverStairway() method to recover the flight
+    // and continue it. This test is similar to the startup recover test, but
+    // exercises the case where the
+
+    Stairway stairway1 = new TestStairwayBuilder().name(stairway1Name).build();
+    Stairway stairway2 =
+        new TestStairwayBuilder()
+            .name(stairway2Name)
+            .continuing(true)
+            .existingStairwaysAreAlive(true)
+            .build();
+
+    FlightMap inputs = new FlightMap();
+
+    Integer initialValue = 0;
+    inputs.put("initialValue", initialValue);
+
+    TestPauseController.setControl(0);
+    String flightId = "recoverOneTest";
+    stairway1.submit(flightId, TestFlightRecovery.class, inputs);
+
+    // Allow time for the flight thread to go to sleep
+    TimeUnit.SECONDS.sleep(5);
+    assertThat(TestUtil.isDone(stairway1, flightId), is(equalTo(false)));
+
+    // Pretend we notice that stairway1 is down. We recover stairway1.
+    // That should rerun the "pause" step of TestFlightRecovery class, this
+    // time with control set to 1 it will complete.
+    TestPauseController.setControl(1);
+    stairway2.recoverStairway(stairway1Name);
+
+    // Wait for recovery to complete
+    stairway2.waitForFlight(flightId, null, null);
+    FlightState result = stairway2.getFlightState(flightId);
+    assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.SUCCESS)));
+    assertTrue(result.getResultMap().isPresent());
+    Integer value = result.getResultMap().get().get("value", Integer.class);
+    assertThat(value, is(equalTo(2)));
+  }
 }

--- a/stairway/src/test/java/bio/terra/stairway/impl/RecoveryTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/RecoveryTest.java
@@ -198,7 +198,8 @@ public class RecoveryTest {
     // The idea here is to start two stairways, run a flight on one that pauses.
     // Then from the second, use the recoverStairway() method to recover the flight
     // and continue it. This test is similar to the startup recover test, but
-    // exercises the case where the
+    // exercises the case where the failure of one stairway instance is detected
+    // and recovered by another stairway.
 
     Stairway stairway1 = new TestStairwayBuilder().name(stairway1Name).build();
     Stairway stairway2 =


### PR DESCRIPTION
In testing with WSM and TCL, I found a few Stairway problems:
- I had removed the `recoverStairway` method, but it is needed. It is added to the Stairway interface and the implementation.
- I added a unit test for `recoverStairway` to make sure it works properly and make sure I won't accidentally delete it again!
- I restored already-exists error handling and logging to the topic and subscription creation methods in `GcpQueueUtils`.
- Added javadoc on public methods in `GcpQueueUtils` as well.

With these changes, my modified versions of TCL and WSM passed WSM unit, connected, and integration tests.