### PR TITLE
PF-1272 Enhanced flight enumeration:

### DIFF
--- a/stairway/src/main/java/bio/terra/stairway/FlightEnumeration.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightEnumeration.java
@@ -1,0 +1,32 @@
+package bio.terra.stairway;
+
+import java.util.List;
+
+/** Class that holds the return value of the enhanced getFlights Stairway entrypoint */
+public class FlightEnumeration {
+  private final int totalFlights;
+  private final String nextPageToken;
+  private final List<FlightState> flightStateList;
+
+  public FlightEnumeration(
+      int totalFlights, String nextPageToken, List<FlightState> flightStateList) {
+    this.totalFlights = totalFlights;
+    this.nextPageToken = nextPageToken;
+    this.flightStateList = flightStateList;
+  }
+
+  /** @return total number of flights in the filtered set */
+  public int getTotalFlights() {
+    return totalFlights;
+  }
+
+  /** @return encoded string describing the start of the next page */
+  public String getNextPageToken() {
+    return nextPageToken;
+  }
+
+  /** @return list of FlightState in this page */
+  public List<FlightState> getFlightStateList() {
+    return flightStateList;
+  }
+}

--- a/stairway/src/main/java/bio/terra/stairway/exception/InvalidPageToken.java
+++ b/stairway/src/main/java/bio/terra/stairway/exception/InvalidPageToken.java
@@ -1,0 +1,17 @@
+package bio.terra.stairway.exception;
+
+/** Invalid flight filter provided to flight enumeration */
+public class InvalidPageToken extends StairwayBadRequestException {
+
+  public InvalidPageToken(String message) {
+    super(message);
+  }
+
+  public InvalidPageToken(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidPageToken(Throwable cause) {
+    super(cause);
+  }
+}

--- a/stairway/src/main/java/bio/terra/stairway/impl/PageToken.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/PageToken.java
@@ -1,0 +1,48 @@
+package bio.terra.stairway.impl;
+
+import bio.terra.stairway.exception.InvalidPageToken;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Base64;
+import org.apache.commons.lang3.StringUtils;
+
+/** Container/converter for a page token */
+public class PageToken {
+  public static final String PAGE_TOKEN_VERSION = "v01";
+  private final Instant timestamp;
+
+  public PageToken(Instant timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public PageToken(String token) {
+    if (!StringUtils.startsWith(token, PAGE_TOKEN_VERSION)) {
+      throw new InvalidPageToken("Invalid page token");
+    }
+
+    try {
+      String encodedInstant = StringUtils.removeStart(token, PAGE_TOKEN_VERSION);
+      String base64String = URLDecoder.decode(encodedInstant, StandardCharsets.UTF_8);
+      String instantString =
+          new String(Base64.getDecoder().decode(base64String), StandardCharsets.UTF_8);
+      timestamp = Instant.parse(instantString);
+    } catch (IllegalArgumentException | DateTimeParseException e) {
+      throw new InvalidPageToken("Invalid page token");
+    }
+  }
+
+  public String makeToken() {
+    String base64String =
+        new String(
+            Base64.getEncoder().encode(timestamp.toString().getBytes(StandardCharsets.UTF_8)),
+            StandardCharsets.UTF_8);
+    return PAGE_TOKEN_VERSION + URLEncoder.encode(base64String, StandardCharsets.UTF_8);
+  }
+
+  public Instant getTimestamp() {
+    return timestamp;
+  }
+}

--- a/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
@@ -4,6 +4,7 @@ import bio.terra.stairway.Control;
 import bio.terra.stairway.ExceptionSerializer;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightDebugInfo;
+import bio.terra.stairway.FlightEnumeration;
 import bio.terra.stairway.FlightFilter;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
@@ -30,6 +31,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,10 +197,9 @@ public class StairwayImpl implements Stairway {
   }
 
   /**
-   * Recover any orphaned flights from a particular Stairway instance.
-   * This method can be called when a server using Stairway discovers that
-   * another Stairway instance has failed. For example, when a Kubernetes listener
-   * notices a pod failure.
+   * Recover any orphaned flights from a particular Stairway instance. This method can be called
+   * when a server using Stairway discovers that another Stairway instance has failed. For example,
+   * when a Kubernetes listener notices a pod failure.
    *
    * @param stairwayName name of a stairway instance to recover
    * @throws InterruptedException interruption during recovery
@@ -530,26 +531,22 @@ public class StairwayImpl implements Stairway {
   }
 
   /**
-   * Enumerate flights - returns a range of flights ordered by submit time. Note that there can be
-   * "jitter" in the paging through flights if new flights are submitted.
-   *
-   * <p>You can add one or more predicates in a filter list. The filters are logically ANDed
-   * together and applied to the input parameters of flights. That lets you add input parameters
-   * (like who is running the flight) and then select by that to show flights being run by that
-   * user. {@link FlightFilter} documents the different filters and their arguments.
-   *
-   * <p>The and limit are applied after the filtering is done.
-   *
-   * @param offset offset of the row ordered by most recent flight first
-   * @param limit limit the number of rows returned
-   * @param filter predicates to apply to filter flights
-   * @return List of FlightState
-   * @throws DatabaseOperationException unexpected database errors
-   * @throws InterruptedException on shutdown
+   * Implementation of getFlights - not for direct use. See {@link Stairway#getFlights(int, int,
+   * FlightFilter)}
    */
   public List<FlightState> getFlights(int offset, int limit, FlightFilter filter)
       throws StairwayException, DatabaseOperationException, InterruptedException {
     return flightDao.getFlights(offset, limit, filter);
+  }
+
+  /**
+   * Implementation of getFlights - not for direct use. See {@link Stairway#getFlights(String,
+   * Integer, FlightFilter)}
+   */
+  public FlightEnumeration getFlights(
+      @Nullable String nextPageToken, @Nullable Integer limit, @Nullable FlightFilter filter)
+      throws StairwayException, DatabaseOperationException, InterruptedException {
+    return flightDao.getFlights(nextPageToken, limit, filter);
   }
 
   /** @return name of this stairway instance */

--- a/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
@@ -37,7 +37,7 @@ public class FilterTest {
     String inputCompareSql =
         String.format("(I.key = 'afield' AND I.value %s :ff%d)", operand, index + 1);
 
-    FlightFilterAccess access = new FlightFilterAccess(filter);
+    FlightFilterAccess access = new FlightFilterAccess(filter, 0, 10, null);
 
     FlightFilterPredicate predicate = filter.getInputPredicates().get(index);
     String flightSql = access.makeFlightPredicateSql(predicate);
@@ -57,7 +57,7 @@ public class FilterTest {
             + " ORDER BY submit_time LIMIT :limit OFFSET :offset";
 
     FlightFilter filter = new FlightFilter();
-    String sql = new FlightFilterAccess(filter).makeSql();
+    String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
     assertThat(sql, equalTo(expect));
   }
 
@@ -78,7 +78,7 @@ public class FilterTest {
             .addFilterFlightClass(FlightFilterOp.EQUAL, TestFlight.class)
             .addFilterFlightStatus(FlightFilterOp.EQUAL, FlightStatus.RUNNING)
             .addFilterSubmitTime(FlightFilterOp.LESS_THAN, complete);
-    String sql = new FlightFilterAccess(filter).makeSql();
+    String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
     assertThat(sql, equalTo(expect));
   }
 
@@ -96,7 +96,7 @@ public class FilterTest {
         new FlightFilter()
             .addFilterInputParameter("email", FlightFilterOp.EQUAL, "ddtest@gmail.com");
 
-    String sql = new FlightFilterAccess(filter).makeSql();
+    String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
     assertThat(sql, equalTo(expect));
   }
 
@@ -116,7 +116,7 @@ public class FilterTest {
             .addFilterInputParameter("email", FlightFilterOp.EQUAL, "ddtest@gmail.com")
             .addFilterFlightClass(FlightFilterOp.EQUAL, TestFlight.class);
 
-    String sql = new FlightFilterAccess(filter).makeSql();
+    String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
     assertThat(sql, equalTo(expect));
   }
 
@@ -139,7 +139,7 @@ public class FilterTest {
             .addFilterInputParameter("email", FlightFilterOp.EQUAL, "ddtest@gmail.com")
             .addFilterInputParameter("name", FlightFilterOp.EQUAL, "dd");
 
-    String sql = new FlightFilterAccess(filter).makeSql();
+    String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
     assertThat(sql, equalTo(expect));
   }
 
@@ -164,7 +164,49 @@ public class FilterTest {
             .addFilterInputParameter("name", FlightFilterOp.EQUAL, "dd")
             .addFilterFlightClass(FlightFilterOp.EQUAL, TestFlight.class);
 
-    String sql = new FlightFilterAccess(filter).makeSql();
+    String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
+    assertThat(sql, equalTo(expect));
+  }
+
+  @Test
+  public void filterForm1NoLimitTest() throws Exception {
+    String expect =
+        "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
+            + " F.output_parameters, F.status, F.serialized_exception"
+            + " FROM flight F"
+            + " ORDER BY submit_time OFFSET :offset";
+
+    FlightFilter filter = new FlightFilter();
+    String sql = new FlightFilterAccess(filter, 0, null, null).makeSql();
+    assertThat(sql, equalTo(expect));
+  }
+
+  @Test
+  public void filterForm1NoOffsetTest() throws Exception {
+    String expect =
+        "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
+            + " F.output_parameters, F.status, F.serialized_exception"
+            + " FROM flight F"
+            + " ORDER BY submit_time LIMIT :limit";
+
+    FlightFilter filter = new FlightFilter();
+    String sql = new FlightFilterAccess(filter, null, 10, null).makeSql();
+    assertThat(sql, equalTo(expect));
+  }
+
+  @Test
+  public void filterForm1PageTokenTest() throws Exception {
+    String expect =
+        "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
+            + " F.output_parameters, F.status, F.serialized_exception"
+            + " FROM flight F"
+            + " WHERE F.submit_time > :pagetoken"
+            + " ORDER BY submit_time LIMIT :limit";
+
+    PageToken pageToken = new PageToken(Instant.now());
+
+    FlightFilter filter = new FlightFilter();
+    String sql = new FlightFilterAccess(filter, null, 10, pageToken.makeToken()).makeSql();
     assertThat(sql, equalTo(expect));
   }
 }

--- a/stairway/src/test/java/bio/terra/stairway/impl/PageTokenTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/PageTokenTest.java
@@ -1,0 +1,43 @@
+package bio.terra.stairway.impl;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import bio.terra.stairway.exception.InvalidPageToken;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class PageTokenTest {
+
+  @Test
+  public void pageTokenTest() throws Exception {
+    Instant testInstant = Instant.now();
+
+    // Make sure we translate properly
+    PageToken token = new PageToken(testInstant);
+    String externalToken = token.makeToken();
+    PageToken validate = new PageToken(externalToken);
+    assertThat(validate.getTimestamp(), equalTo(token.getTimestamp()));
+
+    // Bad version
+    String badVersion =
+        "vxx" + StringUtils.removeStart(externalToken, PageToken.PAGE_TOKEN_VERSION);
+    Assertions.assertThrows(InvalidPageToken.class, () -> new PageToken(badVersion));
+
+    // Bad URL string
+    String badUrl = PageToken.PAGE_TOKEN_VERSION + "     \\";
+    Assertions.assertThrows(InvalidPageToken.class, () -> new PageToken(badUrl));
+
+    // Bad timestamp string
+    String badInstant =
+        PageToken.PAGE_TOKEN_VERSION
+            + URLEncoder.encode("2022-01-01x01:02:03Z", StandardCharsets.UTF_8);
+    Assertions.assertThrows(InvalidPageToken.class, () -> new PageToken(badInstant));
+  }
+}


### PR DESCRIPTION
This PR adds an enhanced flight enumeration endpoint and some bug fixes:
- validate filter inputs to avoid NPE. Previously, passing nulls for filter values would generate NPE.
- fix it so passing null to the complete_time properly filters for incomplete flights
- new getFlights endpoint that uses a nextPageToken in place of offset and returns total flights.
- additional tests to support the new filtering and endpoints