### PR TITLE
DR-2410 add sort on creation time

### DIFF
--- a/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
@@ -126,7 +126,7 @@ public class FlightFilter {
    */
   public FlightFilter addFilterFlightStatus(FlightFilterOp op, FlightStatus status) {
     if (status == null) {
-      throw new FlightFilterException("Status cannot be nul");
+      throw new FlightFilterException("Status cannot be null");
     }
     FlightFilterPredicate predicate =
         new FlightFilterPredicate(
@@ -168,7 +168,7 @@ public class FlightFilter {
    */
   public FlightFilter submittedTimeSortDirection(FlightFilterSortDirection submittedTimeSortDirection) {
     if (submittedTimeSortDirection == null) {
-      throw new FlightFilterException("Sort direction cannot be nul");
+      throw new FlightFilterException("Sort direction cannot be null");
     }
 
     this.submittedTimeSortDirection = submittedTimeSortDirection;

--- a/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
  *     .addFilterFlightClass(EQUAL, IngestFlight.class)
  *     .addFilterFlightStatus(EQUAL, FlightStatus.COMPLETED)
  *     .addFilterInputParameter("email", EQUAL, "ddtest@gmail.com");
+ *     .submittedTimeSortDirection(FlightFilterSortDirection.DESC)
  * }</pre>
  *
  * That filter would return ingest flights completed in the last day (assuming you'd properly set
@@ -26,11 +27,13 @@ import javax.annotation.Nullable;
 public class FlightFilter {
   private final List<FlightFilterPredicate> flightPredicates;
   private final List<FlightFilterPredicate> inputPredicates;
+  private FlightFilterSortDirection submittedTimeSortDirection;
   private int parameterId;
 
   public FlightFilter() {
     flightPredicates = new ArrayList<>();
     inputPredicates = new ArrayList<>();
+    submittedTimeSortDirection = FlightFilterSortDirection.ASC;
     parameterId = 0;
   }
 
@@ -40,6 +43,10 @@ public class FlightFilter {
 
   public List<FlightFilterPredicate> getInputPredicates() {
     return inputPredicates;
+  }
+
+  public FlightFilterSortDirection getSubmittedTimeSortDirection() {
+    return submittedTimeSortDirection;
   }
 
   /**
@@ -150,6 +157,21 @@ public class FlightFilter {
     FlightFilterPredicate predicate =
         new FlightFilterPredicate(key, op, value, Datatype.STRING, makeParameterName());
     inputPredicates.add(predicate);
+    return this;
+  }
+
+  /**
+   * Specify the sort order based on submitted time for the returned values
+   * @param submittedTimeSortDirection wether to sort in ascending (default) or descending order
+   * @return {@code this}, for fluent style
+   * @throws FlightFilterException if the specified value is null
+   */
+  public FlightFilter submittedTimeSortDirection(FlightFilterSortDirection submittedTimeSortDirection) {
+    if (submittedTimeSortDirection == null) {
+      throw new FlightFilterException("Sort direction cannot be nul");
+    }
+
+    this.submittedTimeSortDirection = submittedTimeSortDirection;
     return this;
   }
 

--- a/stairway/src/main/java/bio/terra/stairway/FlightFilterSortDirection.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightFilterSortDirection.java
@@ -1,0 +1,16 @@
+package bio.terra.stairway;
+
+public enum FlightFilterSortDirection {
+  ASC("ASC"),
+  DESC("DESC");
+
+  private final String sql;
+
+  FlightFilterSortDirection(String sql) {
+    this.sql = sql;
+  }
+
+  public String getSql() {
+    return sql;
+  }
+}

--- a/stairway/src/main/java/bio/terra/stairway/Stairway.java
+++ b/stairway/src/main/java/bio/terra/stairway/Stairway.java
@@ -260,7 +260,7 @@ public interface Stairway {
    *
    * @param offset offset of the row ordered by most recent flight first
    * @param limit limit the number of rows returned
-   * @param filter predicates to apply to filter flights
+   * @param filter predicates to apply to filter flights and retrieval options
    * @return List of FlightState
    * @throws StairwayException - other Stairway error
    * @throws DatabaseOperationException unexpected database errors

--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
@@ -3,6 +3,7 @@ package bio.terra.stairway.impl;
 import bio.terra.stairway.FlightFilter;
 import bio.terra.stairway.FlightFilter.FlightFilterPredicate;
 import bio.terra.stairway.FlightFilter.FlightFilterPredicate.Datatype;
+import bio.terra.stairway.FlightFilterSortDirection;
 import bio.terra.stairway.StairwayMapper;
 import bio.terra.stairway.exception.FlightFilterException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -124,8 +125,8 @@ class FlightFilterAccess {
 
     makeSqlQueryCommon(sb);
 
-    // All forms end with the same order by
-    sb.append(" ORDER BY submit_time");
+    // All forms end with the same order by with the variance being ascending or descending order
+    sb.append(" ORDER BY submit_time").append(" ").append(filter.getSubmittedTimeSortDirection().getSql());
 
     // Add the paging controls if present
     if (limit != null) {

--- a/stairway/src/main/resources/stairway/db/changelog.xml
+++ b/stairway/src/main/resources/stairway/db/changelog.xml
@@ -8,4 +8,5 @@
     <include file="changesets/20200421_doing_control.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20201207_debug_info.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20210416_flightworking.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220127_created_at_index.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/stairway/src/main/resources/stairway/db/changesets/20220127_created_at_index.yaml
+++ b/stairway/src/main/resources/stairway/db/changesets/20220127_created_at_index.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: flightworking
+      author: nm
+      changes:
+        - createIndex:
+            indexName: idx_flight_submit_time
+            tableName: flight
+            unique: false
+            columns:
+              - column:
+                  name: submit_time

--- a/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
@@ -2,12 +2,14 @@ package bio.terra.stairway.impl;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightEnumeration;
 import bio.terra.stairway.FlightFilter;
 import bio.terra.stairway.FlightFilterOp;
+import bio.terra.stairway.FlightFilterSortDirection;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
@@ -146,14 +148,26 @@ public class EnumerateFlightsTest {
     flightEnum = flightDao.getFlights(pageTokenString, 3, filter);
     checkResults("case 10", flightEnum.getFlightStateList(), Arrays.asList("3", "4", "5"));
     assertThat(flightEnum.getTotalFlights(), equalTo(6));
+
+    // Case 11: sorting in ascending order
+    filter =
+            new FlightFilter()
+                    .submittedTimeSortDirection(FlightFilterSortDirection.ASC);
+    flightList = flightDao.getFlights(0, 100, filter);
+    checkResults("case 11", flightList, Arrays.asList("0", "1", "2", "3", "4", "5"));
+
+    // Case 12: sorting in descending order
+    filter =
+            new FlightFilter()
+                    .submittedTimeSortDirection(FlightFilterSortDirection.DESC);
+    flightList = flightDao.getFlights(0, 100, filter);
+    checkResults("case 12", flightList, Arrays.asList("5", "4", "3", "2", "1", "0"));
   }
 
   private void checkResults(String name, List<FlightState> resultlList, List<String> expectedIds) {
-    assertThat(
-        name + ": right number of elements", resultlList.size(), equalTo(expectedIds.size()));
     List<String> actualIds =
         resultlList.stream().map(FlightState::getFlightId).collect(Collectors.toList());
-    assertTrue(CollectionUtils.isEqualCollection(actualIds, expectedIds), "elements match");
+    assertThat(name + ": elements match in the correct order", actualIds, contains(expectedIds.toArray()));
   }
 
   private FlightState makeFlight(

--- a/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import bio.terra.stairway.FlightFilter;
 import bio.terra.stairway.FlightFilter.FlightFilterPredicate;
 import bio.terra.stairway.FlightFilterOp;
+import bio.terra.stairway.FlightFilterSortDirection;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.stairway.flights.TestFlight;
 import java.time.Instant;
@@ -54,7 +55,7 @@ public class FilterTest {
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception"
             + " FROM flight F"
-            + " ORDER BY submit_time LIMIT :limit OFFSET :offset";
+            + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter = new FlightFilter();
     String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
@@ -68,7 +69,7 @@ public class FilterTest {
             + " F.output_parameters, F.status, F.serialized_exception"
             + " FROM flight F WHERE"
             + " F.completed_time > :ff1 AND F.class_name = :ff2 AND F.status = :ff3 AND F.submit_time < :ff4"
-            + " ORDER BY submit_time LIMIT :limit OFFSET :offset";
+            + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     Instant submit = now();
     Instant complete = now();
@@ -90,7 +91,7 @@ public class FilterTest {
             + " FROM flight F INNER JOIN flightinput I"
             + " ON F.flightid = I.flightid"
             + " WHERE (I.key = 'email' AND I.value = :ff1)"
-            + " ORDER BY submit_time LIMIT :limit OFFSET :offset";
+            + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter =
         new FlightFilter()
@@ -109,7 +110,7 @@ public class FilterTest {
             + " ON F.flightid = I.flightid"
             + " WHERE (I.key = 'email' AND I.value = :ff1)"
             + " AND F.class_name = :ff2"
-            + " ORDER BY submit_time LIMIT :limit OFFSET :offset";
+            + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter =
         new FlightFilter()
@@ -132,7 +133,7 @@ public class FilterTest {
             + " GROUP BY I.flightid) INPUT"
             + " ON F.flightid = INPUT.flightid"
             + " WHERE INPUT.matchCount = 2"
-            + " ORDER BY submit_time LIMIT :limit OFFSET :offset";
+            + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter =
         new FlightFilter()
@@ -156,7 +157,7 @@ public class FilterTest {
             + " ON F.flightid = INPUT.flightid"
             + " WHERE INPUT.matchCount = 2"
             + " AND F.class_name = :ff3"
-            + " ORDER BY submit_time LIMIT :limit OFFSET :offset";
+            + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter =
         new FlightFilter()
@@ -174,7 +175,7 @@ public class FilterTest {
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception"
             + " FROM flight F"
-            + " ORDER BY submit_time OFFSET :offset";
+            + " ORDER BY submit_time ASC OFFSET :offset";
 
     FlightFilter filter = new FlightFilter();
     String sql = new FlightFilterAccess(filter, 0, null, null).makeSql();
@@ -187,7 +188,7 @@ public class FilterTest {
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception"
             + " FROM flight F"
-            + " ORDER BY submit_time LIMIT :limit";
+            + " ORDER BY submit_time ASC LIMIT :limit";
 
     FlightFilter filter = new FlightFilter();
     String sql = new FlightFilterAccess(filter, null, 10, null).makeSql();
@@ -201,11 +202,28 @@ public class FilterTest {
             + " F.output_parameters, F.status, F.serialized_exception"
             + " FROM flight F"
             + " WHERE F.submit_time > :pagetoken"
-            + " ORDER BY submit_time LIMIT :limit";
+            + " ORDER BY submit_time ASC LIMIT :limit";
 
     PageToken pageToken = new PageToken(Instant.now());
 
     FlightFilter filter = new FlightFilter();
+    String sql = new FlightFilterAccess(filter, null, 10, pageToken.makeToken()).makeSql();
+    assertThat(sql, equalTo(expect));
+  }
+
+  @Test
+  public void filterForm1OrderTest() throws Exception {
+    String expect =
+            "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
+                    + " F.output_parameters, F.status, F.serialized_exception"
+                    + " FROM flight F"
+                    + " WHERE F.submit_time > :pagetoken"
+                    + " ORDER BY submit_time DESC LIMIT :limit";
+
+    PageToken pageToken = new PageToken(Instant.now());
+
+    FlightFilter filter = new FlightFilter()
+            .submittedTimeSortDirection(FlightFilterSortDirection.DESC);
     String sql = new FlightFilterAccess(filter, null, 10, pageToken.makeToken()).makeSql();
     assertThat(sql, equalTo(expect));
   }


### PR DESCRIPTION
This PR allows users to specify sort order when enumerating flights where sort if performed on submitted_time (current behavior is to always sort in ascending order).

I put this in the `FlightFilter` class which isn't super obvious but seemed easier than changing the `getFlights` signature.

I also added a (non-unique) index to the flights table on the created_at column since we always sort on it (and at least on TDR prod) the endpoint that calls to that takes over a minute because we quickly get millions of flights

Last thing: I changed up how flight results are compared in the `EnumerateFlightsTest` unit test so that we can test order

