### PR TITLE
[PF-1761] Bump bumber to 0.0.6

### DIFF
--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ steps.controls.outputs.checkout-branch }}
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
       - name: "Bump the tag to a new version"
-        uses: databiosphere/github-actions/actions/bumper@v0.0.3
+        uses: databiosphere/github-actions/actions/bumper@v0.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           DEFAULT_BUMP: patch

--- a/.github/workflows/bumpMaster.yaml
+++ b/.github/workflows/bumpMaster.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
       - name: "Bump the tag to a new version"
-        uses: databiosphere/github-actions/actions/bumper@v0.0.3
+        uses: databiosphere/github-actions/actions/bumper@v0.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch


### PR DESCRIPTION
Bumber is broken with this error “fatal: unsafe repository ('/github/workspace' is owned by someone else)“

It is related with [`fatal: unsafe repository (REPO is owned by someone else)` with ubuntu 20.04 container · Issue #760 · actions/checkout](https://github.com/actions/checkout/issues/760) 

bumber 0.0.6 fix the issue.