### PR TITLE
[WOR-498] bump liquibase 4.2.1 -> 4.8.0

### DIFF
--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 
     // Database migration
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.2.1'
+    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.8.0'
     implementation group: 'org.yaml', name: 'snakeyaml', version: '1.27'
 
     // JSON processing


### PR DESCRIPTION
Ticket: [WOR-498](https://broadworkbench.atlassian.net/browse/WOR-498)
* There is a [vulnerability](https://nvd.nist.gov/vuln/detail/cve-2022-0839#range-8159160) in liquibase 4.2.1 that is fixed in 4.8.0.
* BPM pulls in stairway through the `terra-common-lib`, so I'll bump the stairway-gcp version there once this has been merged