### PR TITLE
[PF-1542] Move group name to plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'com.jfrog.artifactory' version '4.29.0'
 }
 
-group = 'bio.terra'
-
 // task dependencies is NOT recursively executed on subprojects
 // https://docs.gradle.org/current/userguide/dependency_locking.html#generating_and_updating_dependency_locks
 tasks.named('dependencies') {

--- a/buildSrc/src/main/groovy/stairway.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/stairway.library-conventions.gradle
@@ -17,6 +17,7 @@ tasks.withType(Javadoc) {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
+group = 'bio.terra'
 publishing {
     publications {
         "$project.name"(MavenPublication) {


### PR DESCRIPTION
Move group name to the plugin (sub project)
Current group name definition is not visible during the artifact publish since it is within root project