### PR TITLE
PF-2173 Add more filtering support

### DIFF
--- a/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
@@ -136,6 +136,24 @@ public class FlightFilter {
   }
 
   /**
+   * Filter by flight ids
+   *
+   * @param flightIds A list of flight ids to filter by
+   * @return {@code this}, for fluent style
+   */
+  public FlightFilter addFilterFlightIds(List<String> flightIds) {
+    if (flightIds == null) {
+      throw new FlightFilterException("flightIds can not be null");
+    }
+    FlightFilterPredicate predicate =
+            new FlightFilterPredicate(
+                    "flightid", FlightFilterOp.IN, flightIds, Datatype.LIST, makeParameterName());
+    flightPredicates.add(predicate);
+    return this;
+  }
+
+
+  /**
    * Filter by an input parameter. This is processed by converting the {@code value} into JSON and
    * doing a string comparison against the input parameter stored in the database. The {@code value}
    * object must be <b>exactly</b> the same class as the input parameter.
@@ -154,8 +172,12 @@ public class FlightFilter {
     if (value == null) {
       throw new FlightFilterException("Value cannot be null in an input filter");
     }
-    FlightFilterPredicate predicate =
-        new FlightFilterPredicate(key, op, value, Datatype.STRING, makeParameterName());
+    FlightFilterPredicate predicate;
+    if (op == FlightFilterOp.IN) {
+      predicate = new FlightFilterPredicate(key, op, value, Datatype.LIST, makeParameterName());
+    } else {
+      predicate = new FlightFilterPredicate(key, op, value, Datatype.STRING, makeParameterName());
+    }
     inputPredicates.add(predicate);
     return this;
   }
@@ -233,6 +255,7 @@ public class FlightFilter {
     public enum Datatype {
       STRING,
       TIMESTAMP,
+      LIST,
       NULL
     }
   }

--- a/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
@@ -43,25 +43,25 @@ import javax.annotation.Nullable;
 public class FlightFilter {
   private final List<FlightFilterPredicate> flightPredicates;
   private final List<FlightFilterPredicate> inputPredicates;
-  private FlightBooleanOperationExpression inputBooleanOperationExpression;
+  private FlightBooleanOperationExpression booleanOperationExpression;
   private FlightFilterSortDirection submittedTimeSortDirection;
 
   // Mapper should be used to deserialize to generic Postgres JSON
   private static final ObjectMapper pgJsonMapper = new ObjectMapper();
 
   public FlightFilter() {
-    flightPredicates = new ArrayList<>();
-    inputPredicates = new ArrayList<>();
-    submittedTimeSortDirection = FlightFilterSortDirection.ASC;
+    this(null);
   }
 
   /**
    * Use this constructor to allow for more complex selection criteria. This takes in expression
    * builder methods that are created using static methods on this class.
    */
-  public FlightFilter(FlightBooleanOperationExpression inputBooleanOperationExpression) {
-    this();
-    this.inputBooleanOperationExpression = inputBooleanOperationExpression;
+  public FlightFilter(FlightBooleanOperationExpression booleanOperationExpression) {
+    this.flightPredicates = new ArrayList<>();
+    this.inputPredicates = new ArrayList<>();
+    this.submittedTimeSortDirection = FlightFilterSortDirection.ASC;
+    this.booleanOperationExpression = booleanOperationExpression;
   }
 
   public List<FlightFilterPredicate> getFlightPredicates() {
@@ -72,8 +72,8 @@ public class FlightFilter {
     return inputPredicates;
   }
 
-  public FlightBooleanOperationExpression getInputBooleanOperationExpression() {
-    return inputBooleanOperationExpression;
+  public FlightBooleanOperationExpression getBooleanOperationExpression() {
+    return booleanOperationExpression;
   }
 
   public FlightFilterSortDirection getSubmittedTimeSortDirection() {
@@ -256,8 +256,8 @@ public class FlightFilter {
       values.addAll(predicate.getValues());
     }
 
-    if (inputBooleanOperationExpression != null) {
-      values.addAll(inputBooleanOperationExpression.getValues());
+    if (booleanOperationExpression != null) {
+      values.addAll(booleanOperationExpression.getValues());
     }
     return values;
   }

--- a/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightFilter.java
@@ -463,25 +463,22 @@ public class FlightFilter {
     }
   }
 
+    /**
+     * A predicate that is a boolean operation of other predicates
+     * @param operation The operation to perform
+     * @param expressions Expression that will have the boolean operator applied to them
+     */
   public record FlightBooleanOperationExpression(
           Operation operation, List<FlightFilterPredicateInterface> expressions) implements FlightFilterPredicateInterface {
     /**
-     * Provide builders for expressions to be ANDed together
-     *
-     * @param expressions Builders for expressions. These are created with static methods on this
-     *     class
-     * @return A newly created expression builder
+     * @param expressions Expressions that will be AND-ed together.
      */
     public static FlightBooleanOperationExpression makeAnd(FlightFilterPredicateInterface... expressions) {
       return new FlightBooleanOperationExpression(Operation.AND, List.of(expressions));
     }
 
     /**
-     * Provide builders for expressions to be ORed together
-     *
-     * @param expressions Builders for expressions. These are created with static methods on this
-     *     class
-     * @return A newly created expression builder
+     * @param expressions Expressions that will be OR-ed together.
      */
     public static FlightBooleanOperationExpression makeOr(FlightFilterPredicateInterface... expressions) {
       return new FlightBooleanOperationExpression(Operation.OR, List.of(expressions));

--- a/stairway/src/main/java/bio/terra/stairway/FlightFilterOp.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightFilterOp.java
@@ -6,7 +6,8 @@ public enum FlightFilterOp {
   GREATER_THAN(" > "),
   LESS_THAN(" < "),
   GREATER_EQUAL(" >= "),
-  LESS_EQUAL(" <= ");
+  LESS_EQUAL(" <= "),
+  IN(" IN ");
 
   private final String sql;
 

--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightDao.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightDao.java
@@ -866,49 +866,8 @@ class FlightDao {
    * Get a list of flights and their states. The list may be restricted by providing one or more
    * filters. The filters are logically ANDed together.
    *
-   * <p>For performance, there are three forms of the query.
-   *
-   * <p><bold>Form 1: no input parameter filters</bold>
-   *
-   * <p>When there are no input parameter filters, then we can do a single table query on the flight
-   * table like: {@code SELECT flight.* FROM flight WHERE flight-filters ORDER BY } The WHERE and
-   * flight-filters are omitted if there are none to apply.
-   *
-   * <p><bold>Form 2: one input parameter</bold>
-   *
-   * <p>When there is one input filter restriction, we can do a simple join with a restricting join
-   * against the input table like:
-   *
-   * <pre>{@code
-   * SELECT flight.*
-   * FROM flight JOIN flight_input
-   *   ON flight.flightId = flight_input.flightId
-   * WHERE flight-filters
-   *   AND flight_input.key = 'key' AND flight_input.value = 'json-of-object'
-   * }</pre>
-   *
-   * <bold>Form 3: more than one input parameter</bold>
-   *
-   * <p>This one gets complicated. We do a subquery that filters by the OR of the input filters and
-   * groups by the COUNT of the matches. Only flights where we have inputs that qualify by the
-   * filter will have the right count of matches. The query form is like:
-   *
-   * <pre>{@code
-   * SELECT flight.*
-   * FROM flight
-   * JOIN (SELECT flightId, COUNT(*) AS matchCount
-   *       FROM flight_input
-   *       WHERE (flight_input.key = 'key1' AND flight_input.value = 'json-of-object')
-   *          OR (flight_input.key = 'key1' AND flight_input.value = 'json-of-object')
-   *          OR (flight_input.key = 'key1' AND flight_input.value = 'json-of-object')
-   *       GROUP BY flightId) INPUT
-   * ON flight.flightId = INPUT.flightId
-   * WHERE flight-filters
-   *   AND INPUT.matchCount = 3
-   * }</pre>
-   *
-   * In all cases, the result is sorted and paged like this: (@code ORDER BY submit_time LIMIT
-   * :limit OFFSET :offset}
+   * <p>See {@link bio.terra.stairway.impl.FlightFilterAccess#makeSql()} for more information on the
+   * shape of the sql that gets generated
    *
    * @param offset offset into the result set to start returning
    * @param limit max number of results to return

--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightFactory.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightFactory.java
@@ -5,12 +5,9 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.exception.MakeFlightException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Methods to construct Flight objects given a Flight class or the name of a Flight class. */
 class FlightFactory {
-  private static final Logger logger = LoggerFactory.getLogger(FlightFactory.class);
 
   /**
    * Construct a Flight object given the class
@@ -20,14 +17,13 @@ class FlightFactory {
    * @param context caller-provided context for the flight
    * @return Constructed flight object with steps array
    */
-  static Flight makeFlight(
-      Class<? extends Flight> flightClass, FlightMap inputParameters, Object context) {
+  static <T extends Flight> T makeFlight(
+      Class<T> flightClass, FlightMap inputParameters, Object context) {
     try {
       // Find the flightClass constructor that takes the input parameter map and
       // use it to make the flight.
-      Constructor constructor = flightClass.getConstructor(FlightMap.class, Object.class);
-      Flight flight = (Flight) constructor.newInstance(inputParameters, context);
-      return flight;
+      Constructor<T> constructor = flightClass.getConstructor(FlightMap.class, Object.class);
+      return constructor.newInstance(inputParameters, context);
     } catch (InvocationTargetException
         | NoSuchMethodException
         | InstantiationException

--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
@@ -90,6 +90,7 @@ class FlightFilterAccess {
    * SELECT *
    * FROM flight
    * WHERE (1=1)
+   * AND F.flightid IN ('flightid1', 'flightid2', ...)
    * AND EXISTS (SELECT 0 FROM flightinput I
    *             WHERE F.flightid=I.flightid
    *             AND I.key = 'key'

--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
@@ -206,11 +206,9 @@ class FlightFilterAccess {
       case PREDICATE:
         return makeInputPredicateSql(expression.getBasePredicate());
       case AND, OR:
-        return "("
-            + expression.getExpressions().stream()
-                .map(this::makeBooleanExpressionsFilters)
-                .collect(Collectors.joining(expression.getOperation().getSql()))
-            + ")";
+        return expression.getExpressions().stream()
+            .map(this::makeBooleanExpressionsFilters)
+            .collect(Collectors.joining(expression.getOperation().getSql(), "(", ")"));
       default:
         throw new FlightFilterException("Unrecognized boolean operation");
     }
@@ -334,7 +332,7 @@ class FlightFilterAccess {
             StairwayMapper.getObjectMapper()
                 .writeValueAsString(StairwayMapper.getObjectMapper().writeValueAsString(value)));
       }
-      jsonValue = "[" + StringUtils.join(values, ",") + "]";
+      jsonValue = "[" + String.join(",", values) + "]";
     } else {
       jsonValue = StairwayMapper.getObjectMapper().writeValueAsString(predicate.getValue());
     }

--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
@@ -204,7 +204,16 @@ class FlightFilterAccess {
   // -- boolean expression methods
   private String makeBooleanExpressionsFilters(FlightFilterPredicateInterface expression) {
     if (expression instanceof FlightFilterPredicate expressionAsPredicate) {
-      return makeInputPredicateSql(expressionAsPredicate);
+      switch (expressionAsPredicate.getType()) {
+        case INPUT -> {
+          return makeInputPredicateSql(expressionAsPredicate);
+        }
+        case FLIGHT -> {
+          return makeFlightPredicateSql(expressionAsPredicate);
+        }
+        default -> throw new FlightFilterException(
+            "Unrecognized predicate type: %s".formatted(expressionAsPredicate.getType()));
+      }
     } else if (expression instanceof FlightBooleanOperationExpression expressionAsBooleanOp) {
       return expressionAsBooleanOp.getExpressions().stream()
           .map(this::makeBooleanExpressionsFilters)
@@ -312,7 +321,12 @@ class FlightFilterAccess {
 
     for (FlightFilterPredicateInterface expression : booleanExpression.getExpressions()) {
       if (expression instanceof FlightFilterPredicate expressionAsPredicate) {
-        storeInputPredicateValue(expressionAsPredicate, statement);
+        switch (expressionAsPredicate.getType()) {
+          case INPUT -> storeInputPredicateValue(expressionAsPredicate, statement);
+          case FLIGHT -> storeFlightPredicateValue(expressionAsPredicate, statement);
+          default -> throw new FlightFilterException(
+              "Unrecognized predicate type: %s".formatted(expressionAsPredicate.getType()));
+        }
       } else if (expression instanceof FlightBooleanOperationExpression expressionAsBooleanOp) {
         storeInputPredicateValue(expressionAsBooleanOp, statement);
       } else {

--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightFilterAccess.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.SQLException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -167,9 +166,9 @@ class FlightFilterAccess {
       sb.append(" AND ").append(makeInputPredicateSql(predicate));
     }
 
-    if (filter.getInputBooleanOperationExpression() != null) {
+    if (filter.getBooleanOperationExpression() != null) {
       sb.append(" AND ")
-          .append(makeBooleanExpressionsFilters(filter.getInputBooleanOperationExpression()));
+          .append(makeBooleanExpressionsFilters(filter.getBooleanOperationExpression()));
     }
 
     makeFlightFilter(sb, " AND ");

--- a/stairway/src/main/java/bio/terra/stairway/impl/NamedParameterPreparedStatement.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/NamedParameterPreparedStatement.java
@@ -25,9 +25,9 @@ import org.apache.commons.lang3.StringUtils;
  * types.
  */
 @SuppressFBWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING")
-class NamedParameterPreparedStatement implements AutoCloseable {
-  private PreparedStatement preparedStatement; // prepared statement object
-  private Map<String, Integer> nameIndexMap; // mapping between parameter names and indexes
+public class NamedParameterPreparedStatement implements AutoCloseable {
+  private final PreparedStatement preparedStatement; // prepared statement object
+  private final Map<String, Integer> nameIndexMap; // mapping between parameter names and indexes
 
   /**
    * Construct a prepared statement, extracts named parameters and inserts parameter markers (?

--- a/stairway/src/main/resources/stairway/db/changelog.xml
+++ b/stairway/src/main/resources/stairway/db/changelog.xml
@@ -10,4 +10,5 @@
     <include file="changesets/20210416_flightworking.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220127_created_at_index.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220411_progress.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20221028_input_index.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/stairway/src/main/resources/stairway/db/changesets/20221028_input_index.yaml
+++ b/stairway/src/main/resources/stairway/db/changesets/20221028_input_index.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: inputindex
+      author: nm
+      changes:
+        - createIndex:
+            indexName: flightinput_key_idx
+            tableName: flightinput
+            unique: false
+            columns:
+              - column:
+                  name: key

--- a/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
@@ -252,6 +252,20 @@ public class EnumerateFlightsTest {
             .addFilterInputParameter("in2", FlightFilterOp.IN, Arrays.asList(pojo1, pojo2));
     flightList = flightDao.getFlights(0, 100, filter);
     checkResults("case 21", flightList, Arrays.asList("1", "2", "3", "4"));
+
+    // Case 22: mix of generic boolean with input filter (the two get ANDed)
+    filter =
+        new FlightFilter()
+            .addFilterInputParameter("in2", FlightFilterOp.EQUAL, pojo1)
+            .setFilterInputBooleanOperationParameter(
+                (f) ->
+                    createAnd(
+                        f.makeInputPredicate("in0", FlightFilterOp.EQUAL, int1),
+                        f.makeInputPredicate(
+                            "in1", FlightFilterOp.IN, Arrays.asList(string1, string2))));
+
+    flightList = flightDao.getFlights(0, 100, filter);
+    checkResults("case 22", flightList, Arrays.asList("1"));
   }
 
   private void checkResults(String name, List<FlightState> resultlList, List<String> expectedIds) {

--- a/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
@@ -1,13 +1,13 @@
 package bio.terra.stairway.impl;
 
-import static bio.terra.stairway.FlightFilter.makeAnd;
-import static bio.terra.stairway.FlightFilter.makeOr;
-import static bio.terra.stairway.FlightFilter.makePredicateCompletedTime;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightClass;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightIds;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightStatus;
-import static bio.terra.stairway.FlightFilter.makePredicateInput;
-import static bio.terra.stairway.FlightFilter.makePredicateSubmitTime;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeAnd;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeOr;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateCompletedTime;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightClass;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightIds;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightStatus;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateInput;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateSubmitTime;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.ListUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -174,6 +176,21 @@ public class EnumerateFlightsTest {
     filter = new FlightFilter().submittedTimeSortDirection(FlightFilterSortDirection.DESC);
     flightList = flightDao.getFlights(0, 100, filter);
     checkResults("case 13", flightList, Arrays.asList("5", "4", "3", "2", "1", "0"));
+
+    // Case 14: filter input on an in clause
+    filter =
+            new FlightFilter()
+                    .addFilterInputParameter("in0", FlightFilterOp.IN, Arrays.asList(int1, int2));
+    flightList = flightDao.getFlights(0, 100, filter);
+    checkResults("case 14", flightList, Arrays.asList("1", "2", "3", "4"));
+
+    // Case 15: filter flight on an in clause
+    filter =
+            new FlightFilter()
+                    .addFilterFlightIds(Arrays.asList("0", "1", "3"));
+    flightList = flightDao.getFlights(0, 100, filter);
+    checkResults("case 15", flightList, Arrays.asList("0", "1", "3"));
+
   }
 
   private void checkResults(String name, List<FlightState> resultlList, List<String> expectedIds) {

--- a/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
@@ -1,8 +1,8 @@
 package bio.terra.stairway.impl;
 
-import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.createAnd;
-import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.createOr;
-import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.createPredicate;
+import static bio.terra.stairway.FlightFilter.makeAnd;
+import static bio.terra.stairway.FlightFilter.makeInputPredicate;
+import static bio.terra.stairway.FlightFilter.makeOr;
 import static java.time.Instant.now;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -252,16 +252,12 @@ public class FilterTest {
             + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter =
-        new FlightFilter()
-            .setFilterInputBooleanOperationParameter(
-                f ->
-                    createOr(
-                        createPredicate(
-                            f.makeInputPredicate(
-                                "email", FlightFilterOp.EQUAL, "ddtest@gmail.com")),
-                        createAnd(
-                            f.makeInputPredicate("name", FlightFilterOp.EQUAL, "dd"),
-                            f.makeInputPredicate("resource", FlightFilterOp.EQUAL, "resoureId"))));
+        new FlightFilter(
+            makeOr(
+                makeInputPredicate("email", FlightFilterOp.EQUAL, "ddtest@gmail.com"),
+                makeAnd(
+                    makeInputPredicate("name", FlightFilterOp.EQUAL, "dd"),
+                    makeInputPredicate("resource", FlightFilterOp.EQUAL, "resoureId"))));
 
     String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
     assertThat(sql, equalTo(expect));

--- a/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
@@ -1,5 +1,8 @@
 package bio.terra.stairway.impl;
 
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.createAnd;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.createOr;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.createPredicate;
 import static java.time.Instant.now;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,7 +39,11 @@ public class FilterTest {
   private void testPredicate(FlightFilter filter, int index, String operand) {
     String flightCompareSql = String.format("F.afield %s :ff%d", operand, index + 1);
     String inputCompareSql =
-        String.format("(I.key = 'afield' AND I.value %s :ff%d)", operand, index + 1);
+        String.format(
+            "EXISTS (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid "
+                + "AND I.key = 'afield' "
+                + "AND I.value %s :ff%d)",
+            operand, index + 1);
 
     FlightFilterAccess access = new FlightFilterAccess(filter, 0, 10, null);
 
@@ -47,14 +54,13 @@ public class FilterTest {
     assertThat(inputSql, equalTo(inputCompareSql));
   }
 
-  // There next 6 tests are all the possibilities for
-  // query forms 1, 2, and 3 with and without flight filters
   @Test
-  public void filterForm1NoFilterTest() throws Exception {
+  public void filterNoInputFilterNoFlightFiltersTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
             + " FROM flight F"
+            + " WHERE (1=1)"
             + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter = new FlightFilter();
@@ -63,11 +69,11 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm1WithFilterTest() throws Exception {
+  public void filterNoInputFilterWithFlightFilterTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
-            + " FROM flight F WHERE"
+            + " FROM flight F WHERE (1=1) AND"
             + " F.completed_time > :ff1 AND F.class_name = :ff2 AND F.status = :ff3 AND F.submit_time < :ff4"
             + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
@@ -84,13 +90,14 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm2NoFilterTest() throws Exception {
+  public void filterSingleInputFilterNoFlightFiltersTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
-            + " FROM flight F INNER JOIN flightinput I"
-            + " ON F.flightid = I.flightid"
-            + " WHERE (I.key = 'email' AND I.value = :ff1)"
+            + " FROM flight F"
+            + " WHERE (1=1)"
+            + " AND EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'email' AND I.value = :ff1)"
             + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter =
@@ -102,13 +109,14 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm2WithFilterTest() throws Exception {
+  public void filterSingleInputFilterWithFlightFilterTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
-            + " FROM flight F INNER JOIN flightinput I"
-            + " ON F.flightid = I.flightid"
-            + " WHERE (I.key = 'email' AND I.value = :ff1)"
+            + " FROM flight F"
+            + " WHERE (1=1)"
+            + " AND EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'email' AND I.value = :ff1)"
             + " AND F.class_name = :ff2"
             + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
@@ -122,17 +130,16 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm3NoFilterTest() throws Exception {
+  public void filterMultipleInputFiltersNoFlightFiltersTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
-            + " FROM flight F INNER JOIN "
-            + "(SELECT flightid, COUNT(*) AS matchCount FROM flightinput I"
-            + " WHERE (I.key = 'email' AND I.value = :ff1)"
-            + " OR (I.key = 'name' AND I.value = :ff2)"
-            + " GROUP BY I.flightid) INPUT"
-            + " ON F.flightid = INPUT.flightid"
-            + " WHERE INPUT.matchCount = 2"
+            + " FROM flight F"
+            + " WHERE (1=1)"
+            + " AND EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'email' AND I.value = :ff1)"
+            + " AND EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'name' AND I.value = :ff2)"
             + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
     FlightFilter filter =
@@ -145,17 +152,16 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm3WithFilterTest() throws Exception {
+  public void filterMultipleInputFiltersWithFlightFilterTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
-            + " FROM flight F INNER JOIN "
-            + "(SELECT flightid, COUNT(*) AS matchCount FROM flightinput I"
-            + " WHERE (I.key = 'email' AND I.value = :ff1)"
-            + " OR (I.key = 'name' AND I.value = :ff2)"
-            + " GROUP BY I.flightid) INPUT"
-            + " ON F.flightid = INPUT.flightid"
-            + " WHERE INPUT.matchCount = 2"
+            + " FROM flight F"
+            + " WHERE (1=1)"
+            + " AND EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'email' AND I.value = :ff1)"
+            + " AND EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'name' AND I.value = :ff2)"
             + " AND F.class_name = :ff3"
             + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
 
@@ -170,11 +176,11 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm1NoLimitTest() throws Exception {
+  public void filterNoInputFilterNoLimitTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
-            + " FROM flight F"
+            + " FROM flight F WHERE (1=1)"
             + " ORDER BY submit_time ASC OFFSET :offset";
 
     FlightFilter filter = new FlightFilter();
@@ -183,11 +189,11 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm1NoOffsetTest() throws Exception {
+  public void filterNoInputFilterNoOffsetTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
-            + " FROM flight F"
+            + " FROM flight F WHERE (1=1)"
             + " ORDER BY submit_time ASC LIMIT :limit";
 
     FlightFilter filter = new FlightFilter();
@@ -196,12 +202,12 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm1PageTokenTest() throws Exception {
+  public void filterNoInputFilterPageTokenTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
             + " FROM flight F"
-            + " WHERE F.submit_time > :pagetoken"
+            + " WHERE (1=1) AND F.submit_time > :pagetoken"
             + " ORDER BY submit_time ASC LIMIT :limit";
 
     PageToken pageToken = new PageToken(Instant.now());
@@ -212,12 +218,12 @@ public class FilterTest {
   }
 
   @Test
-  public void filterForm1OrderTest() throws Exception {
+  public void filterNoInputFilterOrderTest() throws Exception {
     String expect =
         "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
             + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
             + " FROM flight F"
-            + " WHERE F.submit_time < :pagetoken"
+            + " WHERE (1=1) AND F.submit_time < :pagetoken"
             + " ORDER BY submit_time DESC LIMIT :limit";
 
     PageToken pageToken = new PageToken(Instant.now());
@@ -225,6 +231,39 @@ public class FilterTest {
     FlightFilter filter =
         new FlightFilter().submittedTimeSortDirection(FlightFilterSortDirection.DESC);
     String sql = new FlightFilterAccess(filter, null, 10, pageToken.makeToken()).makeSql();
+    assertThat(sql, equalTo(expect));
+  }
+
+  @Test
+  public void filterBooleanExpressionTest() throws Exception {
+    String expect =
+        "SELECT F.flightid, F.stairway_id, F.submit_time, F.completed_time,"
+            + " F.output_parameters, F.status, F.serialized_exception, F.class_name"
+            + " FROM flight F"
+            + " WHERE (1=1)"
+            + " AND (EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'email' AND I.value = :ff1)"
+            + " OR"
+            + " (EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'name' AND I.value = :ff2)"
+            + " AND"
+            + " EXISTS"
+            + " (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid AND I.key = 'resource' AND I.value = :ff3)))"
+            + " ORDER BY submit_time ASC LIMIT :limit OFFSET :offset";
+
+    FlightFilter filter =
+        new FlightFilter()
+            .setFilterInputBooleanOperationParameter(
+                f ->
+                    createOr(
+                        createPredicate(
+                            f.makeInputPredicate(
+                                "email", FlightFilterOp.EQUAL, "ddtest@gmail.com")),
+                        createAnd(
+                            f.makeInputPredicate("name", FlightFilterOp.EQUAL, "dd"),
+                            f.makeInputPredicate("resource", FlightFilterOp.EQUAL, "resoureId"))));
+
+    String sql = new FlightFilterAccess(filter, 0, 10, null).makeSql();
     assertThat(sql, equalTo(expect));
   }
 }

--- a/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
@@ -1,9 +1,9 @@
 package bio.terra.stairway.impl;
 
-import static bio.terra.stairway.FlightFilter.makeAnd;
-import static bio.terra.stairway.FlightFilter.makeOr;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightClass;
-import static bio.terra.stairway.FlightFilter.makePredicateInput;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeAnd;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeOr;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightClass;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateInput;
 import static java.time.Instant.now;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,13 +38,13 @@ public class FilterTest {
   }
 
   private void testPredicate(FlightFilter filter, int index, String operand) {
-    String flightCompareSql = String.format("F.afield %s :ff%d", operand, index + 1);
+    String flightCompareSql = String.format("F.afield %s :ff%d", operand, 1);
     String inputCompareSql =
         String.format(
             "EXISTS (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid "
                 + "AND I.key = 'afield' "
                 + "AND I.value %s :ff%d)",
-            operand, index + 1);
+            operand, 1);
 
     FlightFilterAccess access = new FlightFilterAccess(filter, 0, 10, null);
 


### PR DESCRIPTION
This PR introduces some new filtering concepts:
- Adds supports for `IN` operations
- Allows filtering on a list of flights
- Adds the ability to specify arbitrary boolean filters when filtering for flights.  This allows users to construct their own complex filters on input parameters.  E.g.
<pre><code><del>FlightFilter flightFilter =
        new FlightFilter()
            .setFilterInputBooleanOperationParameter(
                f ->
                    createOr(
                        createPredicate(
                            f.makeInputPredicate("foo", FlightFilterOp.EQUAL, null)),
                        createAnd(
                            f.makeInputPredicate("foo", FlightFilterOp.EQUAL, "val"),
                            f.makeInputPredicate("bar", FlightFilterOp.LESS_EQUAL, 42))));
</del>
FlightFilter filter = new FlightFilter(
    makeAnd(
        makePredicateFlightStatus(EQUAL, FlightStatus.ERROR),
        makePredicateInput("other_num", LESS_THAN, 456)),
        makeOr(
            makePredicateInput("email", EQUAL, "ddtest@gmail.com"),
            makePredicateInput("num", GREATER_THAN, 123)))
    .submittedTimeSortDirection(FlightFilterSortDirection.DESC);
</code></pre>
(note the tests have some good examples...happy to add more if needed)
- Improves support for `IS NULL` operations on input parameters (the parameter no longer needs to exist)
- Note: this gets rid of the form1-form2-form3 sql generation in favor or a single approach that chains together `EXISTS` statements.  The PR creates an index on the flight input key field to speed up the approach. I tested on a stairway DB with ~5M flights and ~40M rows in the flight inputs table and the performance is pretty good (~1.5 seconds when doing basic filtering)
- It's worth noting: I left the current mode of adding input filters too for backwards compatibility