### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -31,7 +31,7 @@ jobs:
           echo ::set-output name=semver-part::$SEMVER_PART
           echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -28,8 +28,8 @@ jobs:
             SEMVER_PART=${{ github.event.inputs.bump }}
             CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
           fi
-          echo ::set-output name=semver-part::$SEMVER_PART
-          echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
+          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
+          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bumpMaster.yaml
+++ b/.github/workflows/bumpMaster.yaml
@@ -31,7 +31,7 @@ jobs:
           echo ::set-output name=semver-part::$SEMVER_PART
           echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
       - name: "Bump the tag to a new version"

--- a/.github/workflows/bumpMaster.yaml
+++ b/.github/workflows/bumpMaster.yaml
@@ -28,8 +28,8 @@ jobs:
             SEMVER_PART=${{ github.event.inputs.bump }}
             CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
           fi
-          echo ::set-output name=semver-part::$SEMVER_PART
-          echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
+          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
+          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- use actions/cache@v3 instead of v2
- use actions/upload-artifact@v3 instead of v2
- use setup-node@v3 instead of v2
- replace 'set-output' command