### PR TITLE
Update secret name in GHA

### DIFF
--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -49,6 +49,6 @@ jobs:
         with:
           arguments: "artifactoryPublish"
         env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_REPO_KEY: "libs-snapshot-local"

--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -34,11 +34,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
-          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          token: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Bump the tag to a new version"
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         env:
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: master,develop
           VERSION_FILE_PATH: settings.gradle

--- a/.github/workflows/bumpMaster.yaml
+++ b/.github/workflows/bumpMaster.yaml
@@ -47,6 +47,6 @@ jobs:
         with:
           arguments: "artifactoryPublish"
         env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_REPO_KEY: "libs-release-local"


### PR DESCRIPTION
My undo error handling fix did not get published because the artifactory secrets were out of date.
The secrets are now hooked up to the Broad secret sync-er. This PR is to update one secret name that was slightly different.