### PR TITLE
Boolean query support without a builder pattern

### DIFF
--- a/stairway/src/main/java/bio/terra/stairway/impl/FlightFactory.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/FlightFactory.java
@@ -5,12 +5,9 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.exception.MakeFlightException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Methods to construct Flight objects given a Flight class or the name of a Flight class. */
 class FlightFactory {
-  private static final Logger logger = LoggerFactory.getLogger(FlightFactory.class);
 
   /**
    * Construct a Flight object given the class
@@ -20,14 +17,13 @@ class FlightFactory {
    * @param context caller-provided context for the flight
    * @return Constructed flight object with steps array
    */
-  static Flight makeFlight(
-      Class<? extends Flight> flightClass, FlightMap inputParameters, Object context) {
+  static <T extends Flight> T makeFlight(
+      Class<T> flightClass, FlightMap inputParameters, Object context) {
     try {
       // Find the flightClass constructor that takes the input parameter map and
       // use it to make the flight.
-      Constructor constructor = flightClass.getConstructor(FlightMap.class, Object.class);
-      Flight flight = (Flight) constructor.newInstance(inputParameters, context);
-      return flight;
+      Constructor<T> constructor = flightClass.getConstructor(FlightMap.class, Object.class);
+      return constructor.newInstance(inputParameters, context);
     } catch (InvocationTargetException
         | NoSuchMethodException
         | InstantiationException

--- a/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/EnumerateFlightsTest.java
@@ -1,13 +1,13 @@
 package bio.terra.stairway.impl;
 
-import static bio.terra.stairway.FlightFilter.makeAnd;
-import static bio.terra.stairway.FlightFilter.makeOr;
-import static bio.terra.stairway.FlightFilter.makePredicateCompletedTime;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightClass;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightIds;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightStatus;
-import static bio.terra.stairway.FlightFilter.makePredicateInput;
-import static bio.terra.stairway.FlightFilter.makePredicateSubmitTime;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeAnd;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeOr;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateCompletedTime;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightClass;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightIds;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightStatus;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateInput;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateSubmitTime;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/FilterTest.java
@@ -1,9 +1,9 @@
 package bio.terra.stairway.impl;
 
-import static bio.terra.stairway.FlightFilter.makeAnd;
-import static bio.terra.stairway.FlightFilter.makeOr;
-import static bio.terra.stairway.FlightFilter.makePredicateFlightClass;
-import static bio.terra.stairway.FlightFilter.makePredicateInput;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeAnd;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeOr;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightClass;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateInput;
 import static java.time.Instant.now;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,13 +38,13 @@ public class FilterTest {
   }
 
   private void testPredicate(FlightFilter filter, int index, String operand) {
-    String flightCompareSql = String.format("F.afield %s :ff%d", operand, index + 1);
+    String flightCompareSql = String.format("F.afield %s :ff%d", operand, 1);
     String inputCompareSql =
         String.format(
             "EXISTS (SELECT 0 FROM flightinput I WHERE F.flightid = I.flightid "
                 + "AND I.key = 'afield' "
                 + "AND I.value %s :ff%d)",
-            operand, index + 1);
+            operand, 1);
 
     FlightFilterAccess access = new FlightFilterAccess(filter, 0, 10, null);
 


### PR DESCRIPTION
Using the query support changes as a start, move parameter name creation to the SQL code in `FlightFilterAccess` to avoid needing state to create a boolean filter predicate.