### PR TITLE
Further refactor filter code to avoid needing to type-switch

### DIFF
--- a/stairway/src/main/java/bio/terra/stairway/impl/NamedParameterPreparedStatement.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/NamedParameterPreparedStatement.java
@@ -25,9 +25,9 @@ import org.apache.commons.lang3.StringUtils;
  * types.
  */
 @SuppressFBWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING")
-class NamedParameterPreparedStatement implements AutoCloseable {
-  private PreparedStatement preparedStatement; // prepared statement object
-  private Map<String, Integer> nameIndexMap; // mapping between parameter names and indexes
+public class NamedParameterPreparedStatement implements AutoCloseable {
+  private final PreparedStatement preparedStatement; // prepared statement object
+  private final Map<String, Integer> nameIndexMap; // mapping between parameter names and indexes
 
   /**
    * Construct a prepared statement, extracts named parameters and inserts parameter markers (?


### PR DESCRIPTION
Further refactor filter code to avoid needing to type-switch explicitly (in storeInputPredicateValue) and implicitly (due to overriding on the first argument of storeInputPredicateValue()).

The code has two types of polymorphic behavior that don’t use OOP, but could. Using OOP makes the polymorphism more apparent. The code has two methods on `FlightFliterAccess`:
```
storeInputPredicateValue(FlightBooleanOperationExpression booleanExpression, NamedParameterPreparedStatement statement)
storeInputPredicateValue(FlightFilterPredicate predicate, NamedParameterPreparedStatement statement)
```
In this case `storeInputPredicateValue` is polymorphic with respect to its first argument. Since both of these objects have a common base class (`FlightFilterPredicateInterface`), if you could move the methods out of `FlightFilterAccess` (and into the common base class) you can use OOP to do the polymorphic dispatch for you. To do that you either have to pass in a lambda to set the parameter, or return an object that can be used to later set the parameter. I tried it both ways and returning the object seemed to work better.

The second polymorphism is inside `storeInputPredicateValue(FlightBooleanOperationExpression booleanExpression, NamedParameterPreparedStatement statement)` where it does a type-switch on the subexpression type. It turned out that this could also be replaced with a method call on the base class’s API.