### PR TITLE
[PF-2976] Add Azure Service Bus support to stairway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 tasks.named('dependencies') {
     dependsOn(':stairway:dependencies')
     dependsOn(':stairway-gcp:dependencies')
+    dependsOn(':stairway-azure:dependencies')
     dependsOn(':stairctl:dependencies')
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,8 @@ rootProject.name = 'stairwaySaga'
 include 'stairway'
 include 'stairway-gcp'
 include 'stairctl'
+include 'stairway-azure'
 
 gradle.ext.version = "0.0.78-SNAPSHOT"
+
+

--- a/stairway-azure/build.gradle
+++ b/stairway-azure/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'stairway.library-conventions'
+}
+
+dependencies {
+    api project(':stairway')
+
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+
+    // JSON processing
+    ext {
+        jackson = '2.13.4'
+    }
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson}"
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: "${jackson}"
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "${jackson}"
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: "${jackson}"
+    implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.3'
+
+    //Azure service bus dependencies
+    implementation 'com.azure:azure-messaging-servicebus:7.14.0-beta.1'
+    implementation 'com.azure:azure-identity:1.10.4'
+
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
+}
+
+apply from: "$rootDir/gradle/dependency-locking.gradle"
+apply from: "$rootDir/gradle/test.gradle"

--- a/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
+++ b/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
@@ -10,6 +10,7 @@ import com.azure.messaging.servicebus.ServiceBusMessage;
 import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
 import com.azure.messaging.servicebus.ServiceBusReceiverClient;
 import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
 import java.time.Duration;
 import java.util.List;
 import org.apache.commons.lang3.NotImplementedException;
@@ -65,6 +66,8 @@ public class AzureServiceBusQueue implements QueueInterface {
             .receiver()
             .topicName(builder.topicName)
             .subscriptionName(builder.subscriptionName)
+            .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+            .disableAutoComplete()
             .maxAutoLockRenewDuration(builder.maxAutoLockRenewDuration)
             .buildClient();
 

--- a/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
+++ b/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
@@ -35,7 +35,7 @@ public class AzureServiceBusQueue implements QueueInterface {
    * @param serviceBusReceiverClient the receiver client
    * @param serviceBusSenderClient the sender client
    */
-  public AzureServiceBusQueue(
+  AzureServiceBusQueue(
       ServiceBusReceiverClient serviceBusReceiverClient,
       ServiceBusSenderClient serviceBusSenderClient) {
     this.serviceBusReceiverClient = serviceBusReceiverClient;
@@ -216,7 +216,7 @@ public class AzureServiceBusQueue implements QueueInterface {
       return this;
     }
 
-    public AzureServiceBusQueue build() {
+    public AzureServiceBusQueue build() throws IllegalArgumentException, NullPointerException {
       Validate.notEmpty(subscriptionName, "A subscriptionName is required");
       Validate.notEmpty(topicName, "A topicName is required");
       Validate.inclusiveBetween(

--- a/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
+++ b/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
@@ -1,0 +1,238 @@
+package bio.terra.stairway.azure;
+
+import bio.terra.stairway.QueueInterface;
+import bio.terra.stairway.QueueProcessFunction;
+import bio.terra.stairway.exception.StairwayExecutionException;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.messaging.servicebus.ServiceBusClientBuilder;
+import com.azure.messaging.servicebus.ServiceBusException;
+import com.azure.messaging.servicebus.ServiceBusMessage;
+import com.azure.messaging.servicebus.ServiceBusReceiverClient;
+import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
+import java.util.List;
+import java.time.Duration;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AzureServiceBusQueue implements QueueInterface {
+
+  private static final Logger logger = LoggerFactory.getLogger(AzureServiceBusQueue.class);
+
+  private final ServiceBusReceiverClient serviceBusReceiverClient;
+  private final ServiceBusSenderClient serviceBusSenderClient;
+
+  public static AzureServiceBusQueue.Builder newBuilder() {
+    return new AzureServiceBusQueue.Builder();
+  }
+
+  /**
+   * Construct the queue by creating a receiver and sender client for reading and writing to the
+   * subscription and reading from the topic.
+   *
+   * @param serviceBusReceiverClient the receiver client
+   * @param serviceBusSenderClient the sender client
+   */
+  public AzureServiceBusQueue(
+      ServiceBusReceiverClient serviceBusReceiverClient,
+      ServiceBusSenderClient serviceBusSenderClient) {
+    this.serviceBusReceiverClient = serviceBusReceiverClient;
+    this.serviceBusSenderClient = serviceBusSenderClient;
+  }
+
+  /**
+   * Construct the queue by creating a receiver and sender client using the builder parameters.
+   *
+   * @param builder the builder used to pass parameters
+   */
+  public AzureServiceBusQueue(AzureServiceBusQueue.Builder builder) {
+    ServiceBusClientBuilder serviceBusClientBuilder;
+
+    if (builder.useManagedIdentity) {
+      serviceBusClientBuilder =
+          new ServiceBusClientBuilder().credential(new DefaultAzureCredentialBuilder().build());
+    } else {
+      serviceBusClientBuilder =
+          new ServiceBusClientBuilder().connectionString(builder.connectionString);
+    }
+
+    serviceBusReceiverClient =
+        serviceBusClientBuilder
+            .receiver()
+            .topicName(builder.topicName)
+            .subscriptionName(builder.subscriptionName)
+            .maxAutoLockRenewDuration(builder.maxAutoLockRenewDuration)
+            .buildClient();
+
+    serviceBusSenderClient =
+        serviceBusClientBuilder.sender().topicName(builder.topicName).buildClient();
+  }
+
+  /**
+   * Reads a message from Service Bus using the receiver client. The receive operation uses
+   * peek-lock semantics. The message is acknowledged after it has been successfully processed. If
+   * the message fails to be processed, the message will be abandoned (placed back on the
+   * queue/subscription).
+   */
+  @Override
+  public void dispatchMessages(int maxMessages, QueueProcessFunction processFunction)
+      throws InterruptedException {
+
+    // Iterating over a list instead of a stream().forEach() so that the interrupted exception can
+    // be re-thrown
+    List<ServiceBusReceivedMessage> messages =
+        serviceBusReceiverClient.receiveMessages(maxMessages).stream().toList();
+
+    for (ServiceBusReceivedMessage message : messages) {
+      ProcessMessage(processFunction, message);
+    }
+  }
+
+  private void ProcessMessage(
+      QueueProcessFunction processFunction, ServiceBusReceivedMessage message)
+      throws InterruptedException {
+    try {
+      // toString uses StandardCharsets.UTF_8 by default
+      boolean processSucceeded = processFunction.apply(message.getBody().toString());
+
+      if (processSucceeded)
+      {
+        serviceBusReceiverClient.complete(message);
+        logger.info("Completed message. ID: {}", message.getMessageId());
+        return;
+      };
+
+      logger.info("Failed to process message. ID: {}", message.getMessageId());
+      serviceBusReceiverClient.abandon(message);
+
+    } catch (InterruptedException ex) {
+      logger.error("InterruptedException was thrown. Processing will stop", ex);
+      serviceBusReceiverClient.abandon(message);
+      throw ex;
+    } catch (Exception ex) {
+      logger.warn(
+          "Unexpected exception dispatching or processing messages - continuing",
+          ex);
+      serviceBusReceiverClient.abandon(message);
+    }
+  }
+
+  /**
+   * Enqueues a message to Service Bus using the sender client.
+   *
+   * @param message the message to enqueue
+   * @throws StairwayExecutionException if an unexpected Service Bus exception occurs
+   */
+  @Override
+  public void enqueueMessage(String message) throws StairwayExecutionException {
+    try {
+      ServiceBusMessage serviceBusMessage = new ServiceBusMessage(message);
+      serviceBusSenderClient.sendMessage(serviceBusMessage);
+      logger.info("Successfully sent message. ID: {}", serviceBusMessage.getMessageId());
+    } catch (ServiceBusException ex) {
+      logger.error("Unexpected exception sending the message via Azure Service Bus", ex);
+      throw new StairwayExecutionException(
+          "Unexpected exception sending the message via Azure Service Bus", ex);
+    }
+  }
+
+  @Override
+  public void purgeQueueForTesting() {
+    throw new NotImplementedException(
+        "purgeQueueForTesting is not implemented for Azure Service Bus");
+  }
+
+  /** Use this builder class to create the AzurePubSubQueue. */
+  public static class Builder {
+    public Duration maxAutoLockRenewDuration = Duration.ofMinutes(15);
+    private String connectionString;
+    private boolean useManagedIdentity;
+    private String namespace;
+    private String topicName;
+    private String subscriptionName;
+
+    /**
+     * Set the maximum duration for which the lock on each message will be renewed automatically.
+     */
+    public Builder maxAutoLockRenewDuration(Duration maxAutoLockRenewDuration) {
+      this.maxAutoLockRenewDuration = maxAutoLockRenewDuration;
+      return this;
+    }
+
+    /**
+     * Set the connection string for the Azure Service Bus namespace.
+     *
+     * @param connectionString the connection string
+     * @return this
+     */
+    public Builder connectionString(String connectionString) {
+      this.connectionString = connectionString;
+      return this;
+    }
+
+    /**
+     * Set the flag to use managed identity for Azure Service Bus. If this is set, the namespace
+     * must be set.
+     *
+     * @param useManagedIdentity the flag to use managed identity
+     * @return this
+     */
+    public Builder useManagedIdentity(boolean useManagedIdentity) {
+      this.useManagedIdentity = useManagedIdentity;
+      return this;
+    }
+
+    /**
+     * Set the namespace for the Azure Service Bus. Required if using managed identity.
+     *
+     * @param namespace the namespace
+     * @return this
+     */
+    public Builder namespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    /**
+     * Set the topic name where messages will be sent.
+     *
+     * @param topicName the topic name
+     * @return this
+     */
+    public Builder topicName(String topicName) {
+      this.topicName = topicName;
+      return this;
+    }
+
+    /**
+     * Set the subscription name where messages will be received.
+     *
+     * @param subscriptionName the subscription name
+     * @return this
+     */
+    public Builder subscriptionName(String subscriptionName) {
+      this.subscriptionName = subscriptionName;
+      return this;
+    }
+
+    public AzureServiceBusQueue build() {
+      Validate.notEmpty(subscriptionName, "A subscriptionName is required");
+      Validate.notEmpty(topicName, "A topicName is required");
+      Validate.inclusiveBetween(
+          maxAutoLockRenewDuration,
+          Duration.ofSeconds(10),
+          Duration.ofMinutes(30),
+          "maxAutoLockRenewDuration must be between 10 seconds and 30 minutes");
+
+      if (useManagedIdentity) {
+        Validate.notEmpty(namespace, "A namespace is required");
+        return new AzureServiceBusQueue(this);
+      }
+
+      Validate.notEmpty(connectionString, "A connectionString is required");
+      return new AzureServiceBusQueue(this);
+    }
+  }
+}

--- a/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
+++ b/stairway-azure/src/main/java/bio/terra/stairway/azure/AzureServiceBusQueue.java
@@ -91,11 +91,13 @@ public class AzureServiceBusQueue implements QueueInterface {
         serviceBusReceiverClient.receiveMessages(maxMessages).stream().toList();
 
     for (ServiceBusReceivedMessage message : messages) {
-      ProcessMessage(processFunction, message);
+      processMessage(processFunction, message);
     }
+
+    serviceBusReceiverClient.close();
   }
 
-  private void ProcessMessage(
+  private void processMessage(
       QueueProcessFunction processFunction, ServiceBusReceivedMessage message)
       throws InterruptedException {
     try {
@@ -144,6 +146,17 @@ public class AzureServiceBusQueue implements QueueInterface {
   public void purgeQueueForTesting() {
     throw new NotImplementedException(
         "purgeQueueForTesting is not implemented for Azure Service Bus");
+  }
+
+  /** Closes the receiver and sender clients. */
+  public void shutdown() {
+    try {
+      serviceBusReceiverClient.close();
+      serviceBusSenderClient.close();
+    } catch (Exception ex) {
+      logger.error("Unexpected exception closing the Azure Service Bus clients", ex);
+      throw ex;
+    }
   }
 
   /** Use this builder class to create the AzurePubSubQueue. */

--- a/stairway-azure/src/test/java/bio/terra/stairway/azure/AzureServiceBusQueueTest.java
+++ b/stairway-azure/src/test/java/bio/terra/stairway/azure/AzureServiceBusQueueTest.java
@@ -1,0 +1,89 @@
+package bio.terra.stairway.azure;
+
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.IterableStream;
+import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
+import com.azure.messaging.servicebus.ServiceBusReceiverClient;
+import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class AzureServiceBusQueueTest {
+
+    private AzureServiceBusQueue azureServiceBusQueue;
+    @Mock
+    private ServiceBusReceivedMessage receivedMessage;
+    @Mock
+    private ServiceBusReceiverClient serviceBusReceiverClient;
+    @Mock
+    private ServiceBusSenderClient serviceBusSenderClient;
+
+    @BeforeEach
+    void setUp() {
+        azureServiceBusQueue = new AzureServiceBusQueue(serviceBusReceiverClient, serviceBusSenderClient);
+    }
+
+    @Test
+    void newBuilder() {
+    }
+
+    @Test
+    void dispatchMessages_messageIsReceivedAndProcessedSuccessfully_messageIsComplete() throws InterruptedException {
+
+        //set up service bus receiver client mock to return a message
+        when(serviceBusReceiverClient.receiveMessages(1))
+                .thenReturn(IterableStream.of(List.of(receivedMessage)));
+        when(receivedMessage.getBody()).thenReturn(BinaryData.fromString("test"));
+
+        azureServiceBusQueue.dispatchMessages(1, message -> true);
+
+        //verify that the message is set complete
+        verify(serviceBusReceiverClient,times(1)).complete(receivedMessage);
+    }
+    @Test
+    void dispatchMessages_messageIsReceivedAndProcessedUnSuccessfully_messageIsAbandon() throws InterruptedException {
+
+        //set up service bus receiver client mock to return a message
+        when(serviceBusReceiverClient.receiveMessages(1))
+                .thenReturn(IterableStream.of(List.of(receivedMessage)));
+        when(receivedMessage.getBody()).thenReturn(BinaryData.fromString("test"));
+
+        azureServiceBusQueue.dispatchMessages(1, message -> false);
+
+        //verify that the message is set complete
+        verify(serviceBusReceiverClient,times(0)).complete(receivedMessage);
+        verify(serviceBusReceiverClient,times(1)).abandon(receivedMessage);
+    }
+    @Test
+    void dispatchMessages_messageIsReceivedProcessingThrows_MessageIsAbandon() throws InterruptedException {
+
+        //set up service bus receiver client mock to return a message
+        when(serviceBusReceiverClient.receiveMessages(1))
+                .thenReturn(IterableStream.of(List.of(receivedMessage)));
+        when(receivedMessage.getBody()).thenReturn(BinaryData.fromString("test"));
+
+        azureServiceBusQueue.dispatchMessages(1, message -> {throw new RuntimeException("test");});
+
+        //verify that the message is set complete
+        verify(serviceBusReceiverClient,times(0)).complete(receivedMessage);
+        verify(serviceBusReceiverClient,times(1)).abandon(receivedMessage);
+    }
+
+    @Test
+    void enqueueMessage() {
+    }
+}

--- a/stairway-azure/src/test/java/bio/terra/stairway/azure/AzureServiceBusQueueTest.java
+++ b/stairway-azure/src/test/java/bio/terra/stairway/azure/AzureServiceBusQueueTest.java
@@ -8,9 +8,8 @@ import static org.mockito.Mockito.when;
 
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.IterableStream;
-import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
-import com.azure.messaging.servicebus.ServiceBusReceiverClient;
-import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import com.azure.messaging.servicebus.*;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -21,6 +20,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @Tag("unit")
 @ExtendWith(MockitoExtension.class)
+@SuppressFBWarnings(
+    value = "THROWS_METHOD_THROWS_CLAUSE_THROWABLE",
+    justification = "Includes test-only lambdas that throw exceptions")
 class AzureServiceBusQueueTest {
 
   private AzureServiceBusQueue azureServiceBusQueue;
@@ -71,7 +73,7 @@ class AzureServiceBusQueueTest {
     azureServiceBusQueue.dispatchMessages(
         1,
         message -> {
-          throw new RuntimeException("test");
+          throw new ServiceBusException(new RuntimeException("test"), new ServiceBusErrorSource());
         });
 
     // verify that the message is set complete

--- a/stairway-azure/src/test/java/bio/terra/stairway/azure/AzureServiceBusQueueTest.java
+++ b/stairway-azure/src/test/java/bio/terra/stairway/azure/AzureServiceBusQueueTest.java
@@ -1,10 +1,17 @@
 package bio.terra.stairway.azure;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.IterableStream;
 import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
 import com.azure.messaging.servicebus.ServiceBusReceiverClient;
 import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -12,78 +19,93 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-
-
-import java.util.List;
-
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-
 @Tag("unit")
 @ExtendWith(MockitoExtension.class)
 class AzureServiceBusQueueTest {
 
-    private AzureServiceBusQueue azureServiceBusQueue;
-    @Mock
-    private ServiceBusReceivedMessage receivedMessage;
-    @Mock
-    private ServiceBusReceiverClient serviceBusReceiverClient;
-    @Mock
-    private ServiceBusSenderClient serviceBusSenderClient;
+  private AzureServiceBusQueue azureServiceBusQueue;
+  @Mock private ServiceBusReceivedMessage receivedMessage;
+  @Mock private ServiceBusReceiverClient serviceBusReceiverClient;
+  @Mock private ServiceBusSenderClient serviceBusSenderClient;
 
-    @BeforeEach
-    void setUp() {
-        azureServiceBusQueue = new AzureServiceBusQueue(serviceBusReceiverClient, serviceBusSenderClient);
-    }
+  @BeforeEach
+  void setUp() {
+    azureServiceBusQueue =
+        new AzureServiceBusQueue(serviceBusReceiverClient, serviceBusSenderClient);
+  }
 
-    @Test
-    void newBuilder() {
-    }
+  @Test
+  void dispatchMessages_messageIsReceivedAndProcessedSuccessfully_messageIsComplete()
+      throws InterruptedException {
 
-    @Test
-    void dispatchMessages_messageIsReceivedAndProcessedSuccessfully_messageIsComplete() throws InterruptedException {
+    // set up service bus receiver client mock to return a message
+    setUpReceiverClient();
 
-        //set up service bus receiver client mock to return a message
-        when(serviceBusReceiverClient.receiveMessages(1))
-                .thenReturn(IterableStream.of(List.of(receivedMessage)));
-        when(receivedMessage.getBody()).thenReturn(BinaryData.fromString("test"));
+    azureServiceBusQueue.dispatchMessages(1, message -> true);
 
-        azureServiceBusQueue.dispatchMessages(1, message -> true);
+    // verify that the message is set complete
+    verify(serviceBusReceiverClient, times(1)).complete(receivedMessage);
+  }
 
-        //verify that the message is set complete
-        verify(serviceBusReceiverClient,times(1)).complete(receivedMessage);
-    }
-    @Test
-    void dispatchMessages_messageIsReceivedAndProcessedUnSuccessfully_messageIsAbandon() throws InterruptedException {
+  @Test
+  void dispatchMessages_messageIsReceivedAndProcessedUnSuccessfully_messageIsAbandon()
+      throws InterruptedException {
 
-        //set up service bus receiver client mock to return a message
-        when(serviceBusReceiverClient.receiveMessages(1))
-                .thenReturn(IterableStream.of(List.of(receivedMessage)));
-        when(receivedMessage.getBody()).thenReturn(BinaryData.fromString("test"));
+    // set up service bus receiver client mock to return a message
+    setUpReceiverClient();
 
-        azureServiceBusQueue.dispatchMessages(1, message -> false);
+    azureServiceBusQueue.dispatchMessages(1, message -> false);
 
-        //verify that the message is set complete
-        verify(serviceBusReceiverClient,times(0)).complete(receivedMessage);
-        verify(serviceBusReceiverClient,times(1)).abandon(receivedMessage);
-    }
-    @Test
-    void dispatchMessages_messageIsReceivedProcessingThrows_MessageIsAbandon() throws InterruptedException {
+    // verify that the message is set complete
+    verify(serviceBusReceiverClient, times(0)).complete(receivedMessage);
+    verify(serviceBusReceiverClient, times(1)).abandon(receivedMessage);
+  }
 
-        //set up service bus receiver client mock to return a message
-        when(serviceBusReceiverClient.receiveMessages(1))
-                .thenReturn(IterableStream.of(List.of(receivedMessage)));
-        when(receivedMessage.getBody()).thenReturn(BinaryData.fromString("test"));
+  @Test
+  void dispatchMessages_messageIsReceivedProcessingThrows_MessageIsAbandon()
+      throws InterruptedException {
 
-        azureServiceBusQueue.dispatchMessages(1, message -> {throw new RuntimeException("test");});
+    // set up service bus receiver client mock to return a message
+    setUpReceiverClient();
 
-        //verify that the message is set complete
-        verify(serviceBusReceiverClient,times(0)).complete(receivedMessage);
-        verify(serviceBusReceiverClient,times(1)).abandon(receivedMessage);
-    }
+    azureServiceBusQueue.dispatchMessages(
+        1,
+        message -> {
+          throw new RuntimeException("test");
+        });
 
-    @Test
-    void enqueueMessage() {
-    }
+    // verify that the message is set complete
+    verify(serviceBusReceiverClient, times(0)).complete(receivedMessage);
+    verify(serviceBusReceiverClient, times(1)).abandon(receivedMessage);
+  }
+
+  @Test
+  void dispatchMessages_interruptedExceptionIsThrown_throwsInterruptedException() {
+
+    // set up service bus receiver client mock to return a message
+    setUpReceiverClient();
+
+    assertThrows(
+        InterruptedException.class,
+        () ->
+            azureServiceBusQueue.dispatchMessages(
+                1,
+                message -> {
+                  throw new InterruptedException("test");
+                }));
+  }
+
+  private void setUpReceiverClient() {
+    when(serviceBusReceiverClient.receiveMessages(1))
+        .thenReturn(IterableStream.of(List.of(receivedMessage)));
+    when(receivedMessage.getBody()).thenReturn(BinaryData.fromString("test"));
+  }
+
+  @Test
+  void enqueueMessage_messageEnqueued_clientSendsMessage() {
+
+    azureServiceBusQueue.enqueueMessage("test");
+
+    verify(serviceBusSenderClient, times(1)).sendMessage(any());
+  }
 }

--- a/stairway-azure/src/test/java/bio/terra/stairway/azure/QueueBuilderTest.java
+++ b/stairway-azure/src/test/java/bio/terra/stairway/azure/QueueBuilderTest.java
@@ -2,6 +2,7 @@ package bio.terra.stairway.azure;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @Tag("unit")
 @ExtendWith(MockitoExtension.class)
+@SuppressFBWarnings(
+    value = "THROWS_METHOD_THROWS_CLAUSE_THROWABLE",
+    justification = "Includes test-only lambdas that throw exceptions")
 class QueueBuilderTest {
   private AzureServiceBusQueue.Builder builder;
   private static final String SB_NAMESPACE = "foo.servicebus.windows.net";

--- a/stairway-azure/src/test/java/bio/terra/stairway/azure/QueueBuilderTest.java
+++ b/stairway-azure/src/test/java/bio/terra/stairway/azure/QueueBuilderTest.java
@@ -1,0 +1,78 @@
+package bio.terra.stairway.azure;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class QueueBuilderTest {
+  private AzureServiceBusQueue.Builder builder;
+  private static final String SB_NAMESPACE = "foo.servicebus.windows.net";
+  private static final String SB_CONN_STRING =
+      "Endpoint=sb://foo.servicebus.windows.net/;SharedAccessKeyName=fortesting;SharedAccessKey=XXXXXXXXXXXX";
+
+  @BeforeEach
+  void setUp() {
+    builder = AzureServiceBusQueue.newBuilder();
+  }
+
+  @Test
+  void build_noSubscriptionOrTopic_throwsException() {
+
+    assertThrows(NullPointerException.class, () -> builder.build());
+  }
+
+  // Test that the builder throws if managed identity is true and the namespace is missing
+  @Test
+  void build_managedIdentityTrueAndNamespaceMissing_throwsException() {
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            builder
+                .subscriptionName("subscriptionName")
+                .topicName("topicName")
+                .useManagedIdentity(true)
+                .build());
+  }
+
+  // Test that the builder succeeds if managed identity is true and the namespace is provided
+  @Test
+  void build_managedIdentityTrueAndNamespaceProvided_succeeds() {
+    builder
+        .subscriptionName("subscriptionName")
+        .topicName("topicName")
+        .useManagedIdentity(true)
+        .namespace(SB_NAMESPACE)
+        .build();
+  }
+
+  // Test that the builder throws if managed identity is false and the connection string is missing
+  @Test
+  void build_managedIdentityFalseAndConnectionStringMissing_throwsException() {
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            builder
+                .subscriptionName("subscriptionName")
+                .topicName("topicName")
+                .useManagedIdentity(false)
+                .build());
+  }
+
+  // Test that the builder succeeds if managed identity is false and the connection string is
+  // provided
+  @Test
+  void build_managedIdentityFalseAndConnectionStringProvided_succeeds() {
+    builder
+        .subscriptionName("subscriptionName")
+        .topicName("topicName")
+        .useManagedIdentity(false)
+        .connectionString(SB_CONN_STRING)
+        .build();
+  }
+}


### PR DESCRIPTION
This PR:
- Introduces a module `stairway-azure` that implements `QueueInterface` for Azure Service Bus using a topic/subscription model.
- The module allows authentication with either managed identity (MI) or a connection string.
- Read operations use peek-lock semantics, meaning that messages are sent back to the subscription (queue) in case of processing failures.

 