### PR TITLE
Revert "[PF-2987]: Bump org.springframework.boot from 2.7.3 to 3.2.3"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/stairctl/build.gradle
+++ b/stairctl/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'stairway.java-conventions'
 
     id 'io.spring.dependency-management' version '1.0.13.RELEASE'
-    id 'org.springframework.boot' version '3.2.3'
+    id 'org.springframework.boot' version '2.7.3'
 }
 
 version = gradle.version


### PR DESCRIPTION
Reverts DataBiosphere/stairway#123

The version bump commit failed:

```
* What went wrong:
A problem occurred configuring project ':stairctl'.
> Could not resolve all files for configuration ':stairctl:classpath'.
   > Could not resolve org.springframework.boot:spring-boot-gradle-plugin:3.2.3.
     Required by:
         project :stairctl > org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.3
      > No matching variant of org.springframework.boot:spring-boot-gradle-plugin:3.2.3 was found. The consumer was configured to find a runtime of a library compatible with Java 11, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '7.6.4' but:
          - Variant 'apiElements' capability org.springframework.boot:spring-boot-gradle-plugin:3.2.3 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 17 and the consumer needed a runtime of a component compatible with Java 11
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6.4')
          - Variant 'javadocElements' capability org.springframework.boot:spring-boot-gradle-plugin:3.2.3 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 11)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6.4')
          - Variant 'mavenOptionalApiElements' capability org.springframework.boot:spring-boot-gradle-plugin-maven-optional:3.2.3 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 17 and the consumer needed a runtime of a component compatible with Java 11