### PR TITLE
[WOR-1531] Upgrade postgresql to 42.7.2

### DIFF
--- a/buildSrc/src/main/groovy/stairway.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/stairway.java-conventions.gradle
@@ -15,6 +15,9 @@ dependencies {
     // For logging
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
 
+    // Database
+    runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.2'
+
     // For testing
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.0'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.0'

--- a/stairctl/build.gradle
+++ b/stairctl/build.gradle
@@ -28,5 +28,5 @@ dependencies {
     implementation group: 'org.springframework.shell', name: 'spring-shell-starter', version: '2.1.1'
 
     // Database
-    runtimeOnly group: 'org.postgresql', name: 'postgresql'
+    runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.2'
 }

--- a/stairctl/build.gradle
+++ b/stairctl/build.gradle
@@ -26,7 +26,4 @@ dependencies {
     // Spring
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter' // version from spring-boot-plugin
     implementation group: 'org.springframework.shell', name: 'spring-shell-starter', version: '2.1.1'
-
-    // Database
-    runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.2'
 }

--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -26,8 +26,6 @@ dependencies {
     implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.8.0'
     implementation group: 'org.yaml', name: 'snakeyaml', version: '1.27'
 
-    runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.2'
-
     // Google dependencies
     constraints {
         implementation group: 'com.google.guava', name: 'guava', version: '33.0.0-jre' // "-jre" for Java 8 or higher

--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.8.0'
     implementation group: 'org.yaml', name: 'snakeyaml', version: '1.27'
 
-    runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
+    runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.2'
 
     // Google dependencies
     constraints {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1531

Addresses https://nvd.nist.gov/vuln/detail/CVE-2024-1597.  (This minor version bump is currently stuck in a [large Dependabot grouped update](https://github.com/DataBiosphere/stairway/pull/127), so breaking it out.)