### PR TITLE
[WOR-1591] Update "isActive" to include all states

### DIFF
--- a/stairway/src/main/java/bio/terra/stairway/FlightState.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightState.java
@@ -107,7 +107,7 @@ public class FlightState {
   /** Returns true if the flight is not in a terminal state. */
   public boolean isActive() {
     boolean complete =
-        (flightStatus == FlightStatus.RUNNING
+        (flightStatus == FlightStatus.ERROR
             || flightStatus == FlightStatus.FATAL
             || flightStatus == FlightStatus.SUCCESS);
     return !complete;

--- a/stairway/src/main/java/bio/terra/stairway/FlightState.java
+++ b/stairway/src/main/java/bio/terra/stairway/FlightState.java
@@ -104,7 +104,12 @@ public class FlightState {
     return progressMeters;
   }
 
+  /** Returns true if the flight is not in a terminal state. */
   public boolean isActive() {
-    return (flightStatus == FlightStatus.RUNNING);
+    boolean complete =
+        (flightStatus == FlightStatus.RUNNING
+            || flightStatus == FlightStatus.FATAL
+            || flightStatus == FlightStatus.SUCCESS);
+    return !complete;
   }
 }

--- a/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
@@ -497,6 +497,7 @@ public class StairwayImpl implements Stairway {
    * @throws FlightNotFoundException flight id does not exist
    * @throws FlightWaitTimedOutException if interrupted or polling interval expired
    * @throws InterruptedException on shutdown while waiting for flight completion
+   * @deprecated
    */
   public FlightState waitForFlight(String flightId, Integer pollSeconds, Integer pollCycles)
       throws StairwayException,

--- a/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
@@ -133,8 +133,11 @@ public class StairwayImpl implements Stairway {
    */
   public List<String> initialize(
       DataSource dataSource, boolean forceCleanStart, boolean migrateUpgrade)
-      throws StairwayShutdownException, DatabaseOperationException, MigrateException,
-          StairwayException, InterruptedException {
+      throws StairwayShutdownException,
+          DatabaseOperationException,
+          MigrateException,
+          StairwayException,
+          InterruptedException {
 
     // If we have been shut down, do not restart.
     if (isQuietingDown()) {
@@ -176,7 +179,9 @@ public class StairwayImpl implements Stairway {
    * @throws InterruptedException interruption during recovery/startup
    */
   public void recoverAndStart(List<String> obsoleteStairways)
-      throws StairwayException, DatabaseOperationException, InterruptedException,
+      throws StairwayException,
+          DatabaseOperationException,
+          InterruptedException,
           StairwayExecutionException {
 
     if (obsoleteStairways != null) {
@@ -320,8 +325,11 @@ public class StairwayImpl implements Stairway {
       FlightMap inputParameters,
       boolean shouldQueue,
       FlightDebugInfo debugInfo)
-      throws StairwayException, StairwayExecutionException, InterruptedException,
-          DuplicateFlightIdException, MakeFlightException {
+      throws StairwayException,
+          StairwayExecutionException,
+          InterruptedException,
+          DuplicateFlightIdException,
+          MakeFlightException {
     if (flightClass == null || inputParameters == null) {
       throw new MakeFlightException(
           "Must supply non-null flightClass and inputParameters to submit");
@@ -379,8 +387,11 @@ public class StairwayImpl implements Stairway {
       FlightMap inputParameters,
       boolean shouldQueue,
       FlightDebugInfo debugInfo)
-      throws StairwayException, DatabaseOperationException, StairwayExecutionException,
-          InterruptedException, DuplicateFlightIdException {
+      throws StairwayException,
+          DatabaseOperationException,
+          StairwayExecutionException,
+          InterruptedException,
+          DuplicateFlightIdException {
     submit(flightId, flightClass, inputParameters, shouldQueue, debugInfo);
   }
 
@@ -419,7 +430,9 @@ public class StairwayImpl implements Stairway {
    * @throws InterruptedException on shutdown during resume
    */
   public boolean resume(String flightId)
-      throws StairwayException, StairwayShutdownException, DatabaseOperationException,
+      throws StairwayException,
+          StairwayShutdownException,
+          DatabaseOperationException,
           InterruptedException {
     if (isQuietingDown()) {
       throw new StairwayShutdownException("Stairway is shutting down and cannot resume a flight");
@@ -470,10 +483,10 @@ public class StairwayImpl implements Stairway {
   }
 
   /**
-   * Wait for a flight to complete
+   * WARNING: Example implementation of "wait for a flight to complete".
    *
-   * <p>This is a very simple polling method to help you get started with Stairway. It is probably
-   * not what you want for production code.
+   * <p>This is a very simple polling method to help you get started with Stairway. It is not
+   * recommended for production code.
    *
    * @param flightId the flight to wait for
    * @param pollSeconds sleep time for each poll cycle; if null, defaults to 10 seconds
@@ -486,8 +499,11 @@ public class StairwayImpl implements Stairway {
    * @throws InterruptedException on shutdown while waiting for flight completion
    */
   public FlightState waitForFlight(String flightId, Integer pollSeconds, Integer pollCycles)
-      throws StairwayException, DatabaseOperationException, FlightNotFoundException,
-          FlightWaitTimedOutException, InterruptedException {
+      throws StairwayException,
+          DatabaseOperationException,
+          FlightNotFoundException,
+          FlightWaitTimedOutException,
+          InterruptedException {
     int sleepSeconds = (pollSeconds == null) ? 10 : pollSeconds;
     int pollCount = 0;
 
@@ -518,7 +534,9 @@ public class StairwayImpl implements Stairway {
    * @throws InterruptedException on shutdown
    */
   public FlightState getFlightState(String flightId)
-      throws StairwayException, FlightNotFoundException, DatabaseOperationException,
+      throws StairwayException,
+          FlightNotFoundException,
+          DatabaseOperationException,
           InterruptedException {
     return flightDao.getFlightState(flightId);
   }
@@ -565,7 +583,9 @@ public class StairwayImpl implements Stairway {
   }
 
   void exitFlight(FlightContextImpl context)
-      throws StairwayException, DatabaseOperationException, StairwayExecutionException,
+      throws StairwayException,
+          DatabaseOperationException,
+          StairwayExecutionException,
           InterruptedException {
     // save the flight state in the database
     flightDao.exit(context);
@@ -583,7 +603,9 @@ public class StairwayImpl implements Stairway {
   }
 
   private void queueFlight(FlightContextImpl flightContext)
-      throws StairwayException, DatabaseOperationException, StairwayExecutionException,
+      throws StairwayException,
+          DatabaseOperationException,
+          StairwayExecutionException,
           InterruptedException {
     // If the flight state is READY, then we put the flight on the queue and mark it queued in the
     // database. We cannot go directly from RUNNING to QUEUED. Suppose we put the flight in

--- a/stairway/src/test/java/bio/terra/stairway/FlightStateClassTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/FlightStateClassTest.java
@@ -13,10 +13,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("unit")
 public class FlightStateClassTest {
@@ -86,5 +90,28 @@ public class FlightStateClassTest {
         () -> {
           result.getInputParameters().put(BAD, BAD);
         });
+  }
+
+  static Stream<Map<FlightStatus, Boolean>> activeStatuses() {
+    return Stream.of(
+        Map.of(FlightStatus.RUNNING, true),
+        Map.of(FlightStatus.SUCCESS, false),
+        Map.of(FlightStatus.ERROR, false),
+        Map.of(FlightStatus.FATAL, false),
+        Map.of(FlightStatus.WAITING, true),
+        Map.of(FlightStatus.READY, true),
+        Map.of(FlightStatus.QUEUED, true),
+        Map.of(FlightStatus.READY_TO_RESTART, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("activeStatuses")
+  void testActiveFlightStatuses(Map<FlightStatus, Boolean> activeStates) {
+    for (Map.Entry<FlightStatus, Boolean> entry : activeStates.entrySet()) {
+      FlightState flightState = new FlightState();
+      flightState.setFlightStatus(entry.getKey());
+      boolean isActive = entry.getValue();
+      assertThat(flightState.isActive(), is(isActive));
+    }
   }
 }


### PR DESCRIPTION
It appears that `isActive` was implemented before the introduction of a number of new states. Therefore its check for only RUNNING as being "active" meant that other non-terminal states did not get considered "active". I am fixing this, but also encouraging that we do _not_ use `waitForFlight` in our production code. To address [WOR-1591](https://broadworkbench.atlassian.net/browse/WOR-1591) I will be changing the WSM usages of `waitForFlight` to the more robust WSM `FlightUtils.waitForFlightCompletion` implementation.

[WOR-1591]: https://broadworkbench.atlassian.net/browse/WOR-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ