### PR TITLE
[PF-2987]: Bump the minor-patch-dependencies group with 14 updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ tasks.named('dependencies') {
 apply from: "$rootDir/gradle/artifactory.gradle"
 
 sonar {
-    properties {
+    properties { 
         property "sonar.projectKey", "DataBiosphere_stairway"
         property "sonar.organization", "broad-databiosphere"
         property "sonar.host.url", "https://sonarcloud.io"

--- a/stairctl/build.gradle
+++ b/stairctl/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application'
     id 'stairway.java-conventions'
 
-    id 'io.spring.dependency-management' version '1.0.13.RELEASE'
+    id 'io.spring.dependency-management' version '1.1.4'
     id 'org.springframework.boot' version '2.7.3'
 }
 
@@ -18,7 +18,7 @@ dependencies {
 
     // JSON processing
     ext {
-        jackson = '2.16.2'
+        jackson = '2.17.0'
     }
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson}"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "${jackson}"

--- a/stairway-azure/build.gradle
+++ b/stairway-azure/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     // JSON processing
     ext {
-        jackson = '2.16.2'
+        jackson = '2.17.0'
     }
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson}"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: "${jackson}"
@@ -19,8 +19,8 @@ dependencies {
     implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
 
     //Azure service bus dependencies
-    implementation 'com.azure:azure-messaging-servicebus:7.14.0-beta.1'
-    implementation 'com.azure:azure-identity:1.10.4'
+    implementation 'com.azure:azure-messaging-servicebus:7.16.0-beta.1'
+    implementation 'com.azure:azure-identity:1.11.4'
 
     testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
 }

--- a/stairway-gcp/build.gradle
+++ b/stairway-gcp/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     // JSON processing
     ext {
-        jackson = '2.16.2'
+        jackson = '2.17.0'
     }
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson}"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: "${jackson}"
@@ -20,9 +20,9 @@ dependencies {
 
     // Google dependencies
     constraints {
-        implementation group: 'com.google.guava', name: 'guava', version: '33.0.0-jre' // "-jre" for Java 8 or higher
+        implementation group: 'com.google.guava', name: 'guava', version: '33.1.0-jre' // "-jre" for Java 8 or higher
     }
-    implementation platform('com.google.cloud:libraries-bom:26.0.0') // use common bom
+    implementation platform('com.google.cloud:libraries-bom:26.35.0') // use common bom
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
 }
 

--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     // JSON processing
     ext {
-        jackson = '2.16.2'
+        jackson = '2.17.0'
     }
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson}"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava', version: "${jackson}"
@@ -20,21 +20,21 @@ dependencies {
     implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
 
     // Spring
-    implementation group: 'org.springframework', name: 'spring-web', version: '6.1.4'
+    implementation group: 'org.springframework', name: 'spring-web', version: '6.1.5'
 
     // Database
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.8.0'
+    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.27.0'
     implementation group: 'org.yaml', name: 'snakeyaml', version: '1.27'
 
     // Google dependencies
     constraints {
-        implementation group: 'com.google.guava', name: 'guava', version: '33.0.0-jre' // "-jre" for Java 8 or higher
+        implementation group: 'com.google.guava', name: 'guava', version: '33.1.0-jre' // "-jre" for Java 8 or higher
     }
-    implementation platform('com.google.cloud:libraries-bom:26.0.0') // use common bom
+    implementation platform('com.google.cloud:libraries-bom:26.35.0') // use common bom
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
 
     // File handling during testing
-    testImplementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
+    testImplementation group: 'commons-io', name: 'commons-io', version: '2.16.0'
 }
 
 apply from: "$rootDir/gradle/test.gradle"


### PR DESCRIPTION
Bumps the minor-patch-dependencies group with 14 updates:

| Package | From | To |
| --- | --- | --- |
| [com.google.cloud:libraries-bom](https://github.com/googleapis/java-cloud-bom) | `26.0.0` | `26.35.0` | | [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson) | `2.16.2` | `2.17.0` | | [com.fasterxml.jackson.datatype:jackson-datatype-guava](https://github.com/FasterXML/jackson-datatypes-collections) | `2.16.2` | `2.17.0` | | com.fasterxml.jackson.datatype:jackson-datatype-jdk8 | `2.16.2` | `2.17.0` | | com.fasterxml.jackson.datatype:jackson-datatype-jsr310 | `2.16.2` | `2.17.0` | | [com.fasterxml.jackson.module:jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8) | `2.16.2` | `2.17.0` | | [com.fasterxml.jackson.core:jackson-core](https://github.com/FasterXML/jackson-core) | `2.16.2` | `2.17.0` | | [com.fasterxml.jackson.datatype:jackson-datatype-guava](https://github.com/FasterXML/jackson-datatypes-collections) | `2.16.2` | `2.17.0` | | com.fasterxml.jackson.datatype:jackson-datatype-jdk8 | `2.16.2` | `2.17.0` | | com.fasterxml.jackson.datatype:jackson-datatype-jsr310 | `2.16.2` | `2.17.0` | | [com.fasterxml.jackson.module:jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8) | `2.16.2` | `2.17.0` | | [org.springframework:spring-web](https://github.com/spring-projects/spring-framework) | `6.1.4` | `6.1.5` | | [org.liquibase:liquibase-core](https://github.com/liquibase/liquibase) | `4.8.0` | `4.27.0` | | [com.google.guava:guava](https://github.com/google/guava) | `33.0.0-jre` | `33.1.0-jre` | | commons-io:commons-io | `2.15.1` | `2.16.0` |
| [com.fasterxml.jackson.core:jackson-core](https://github.com/FasterXML/jackson-core) | `2.16.2` | `2.17.0` | | [io.spring.dependency-management](https://github.com/spring-gradle-plugins/dependency-management-plugin) | `1.0.13.RELEASE` | `1.1.4` | | [com.azure:azure-messaging-servicebus](https://github.com/Azure/azure-sdk-for-java) | `7.14.0-beta.1` | `7.16.0-beta.1` | | [com.azure:azure-identity](https://github.com/Azure/azure-sdk-for-java) | `1.10.4` | `1.11.4` |


Updates `com.google.cloud:libraries-bom` from 26.0.0 to 26.35.0
- [Release notes](https://github.com/googleapis/java-cloud-bom/releases)
- [Changelog](https://github.com/googleapis/java-cloud-bom/blob/main/release-please-config.json)
- [Commits](https://github.com/googleapis/java-cloud-bom/compare/libraries-bom-v26.0.0...v26.35.0)

Updates `com.fasterxml.jackson.core:jackson-databind` from 2.16.2 to 2.17.0
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `com.fasterxml.jackson.datatype:jackson-datatype-guava` from 2.16.2 to 2.17.0
- [Commits](https://github.com/FasterXML/jackson-datatypes-collections/compare/jackson-datatypes-collections-2.16.2...jackson-datatypes-collections-2.17.0)

Updates `com.fasterxml.jackson.datatype:jackson-datatype-jdk8` from 2.16.2 to 2.17.0

Updates `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` from 2.16.2 to 2.17.0

Updates `com.fasterxml.jackson.module:jackson-module-parameter-names` from 2.16.2 to 2.17.0
- [Commits](https://github.com/FasterXML/jackson-modules-java8/compare/jackson-modules-java8-2.16.2...jackson-modules-java8-2.17.0)

Updates `com.fasterxml.jackson.core:jackson-core` from 2.16.2 to 2.17.0
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.16.2...jackson-core-2.17.0)

Updates `com.fasterxml.jackson.datatype:jackson-datatype-guava` from 2.16.2 to 2.17.0
- [Commits](https://github.com/FasterXML/jackson-datatypes-collections/compare/jackson-datatypes-collections-2.16.2...jackson-datatypes-collections-2.17.0)

Updates `com.fasterxml.jackson.datatype:jackson-datatype-jdk8` from 2.16.2 to 2.17.0

Updates `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` from 2.16.2 to 2.17.0

Updates `com.fasterxml.jackson.module:jackson-module-parameter-names` from 2.16.2 to 2.17.0
- [Commits](https://github.com/FasterXML/jackson-modules-java8/compare/jackson-modules-java8-2.16.2...jackson-modules-java8-2.17.0)

Updates `org.springframework:spring-web` from 6.1.4 to 6.1.5
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v6.1.4...v6.1.5)

Updates `org.liquibase:liquibase-core` from 4.8.0 to 4.27.0
- [Release notes](https://github.com/liquibase/liquibase/releases)
- [Changelog](https://github.com/liquibase/liquibase/blob/master/changelog.txt)
- [Commits](https://github.com/liquibase/liquibase/compare/v4.8.0...v4.27.0)

Updates `com.google.guava:guava` from 33.0.0-jre to 33.1.0-jre
- [Release notes](https://github.com/google/guava/releases)
- [Commits](https://github.com/google/guava/commits)

Updates `commons-io:commons-io` from 2.15.1 to 2.16.0

Updates `com.fasterxml.jackson.core:jackson-core` from 2.16.2 to 2.17.0
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.16.2...jackson-core-2.17.0)

Updates `io.spring.dependency-management` from 1.0.13.RELEASE to 1.1.4
- [Release notes](https://github.com/spring-gradle-plugins/dependency-management-plugin/releases)
- [Commits](https://github.com/spring-gradle-plugins/dependency-management-plugin/compare/v1.0.13.RELEASE...v1.1.4)

Updates `com.azure:azure-messaging-servicebus` from 7.14.0-beta.1 to 7.16.0-beta.1
- [Release notes](https://github.com/Azure/azure-sdk-for-java/releases)
- [Commits](https://github.com/Azure/azure-sdk-for-java/compare/azure-messaging-servicebus_7.14.0-beta.1...azure-messaging-servicebus_7.16.0-beta.1)

Updates `com.azure:azure-identity` from 1.10.4 to 1.11.4
- [Release notes](https://github.com/Azure/azure-sdk-for-java/releases)
- [Commits](https://github.com/Azure/azure-sdk-for-java/compare/azure-identity_1.10.4...azure-identity_1.11.4)

---
updated-dependencies:
- dependency-name: com.google.cloud:libraries-bom dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.core:jackson-databind dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-guava dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-jdk8 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-jsr310 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.module:jackson-module-parameter-names dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.core:jackson-core dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-guava dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-jdk8 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-jsr310 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.module:jackson-module-parameter-names dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: org.springframework:spring-web dependency-type: direct:production update-type: version-update:semver-patch dependency-group: minor-patch-dependencies
- dependency-name: org.liquibase:liquibase-core dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.google.guava:guava dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: commons-io:commons-io dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.fasterxml.jackson.core:jackson-core dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: io.spring.dependency-management dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.azure:azure-messaging-servicebus dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies
- dependency-name: com.azure:azure-identity dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-patch-dependencies ...