### PR TITLE
[DCJ-7] Artifactory publish GHAs set up JDK

### DIFF
--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -17,33 +17,33 @@ jobs:
   development-tag-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Set part of semantic version to bump
-        id: semver
-        run: |
-          SEMVER_PART=""
-          CHECKOUT_BRANCH="$GITHUB_REF"
-          if ${{github.event_name == 'push' }}; then
-            SEMVER_PART="patch"
-          elif ${{github.event_name == 'workflow_dispatch' }}; then
-            SEMVER_PART=${{ github.event.inputs.bump }}
-            CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
-          fi
-          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
-          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
+#      - name: Set part of semantic version to bump
+#        id: semver
+#        run: |
+#          SEMVER_PART=""
+#          CHECKOUT_BRANCH="$GITHUB_REF"
+#          if ${{github.event_name == 'push' }}; then
+#            SEMVER_PART="patch"
+#          elif ${{github.event_name == 'workflow_dispatch' }}; then
+#            SEMVER_PART=${{ github.event.inputs.bump }}
+#            CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
+#          fi
+#          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
+#          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
           token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: "Bump the tag to a new version"
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-          DEFAULT_BUMP: patch
-          RELEASE_BRANCHES: master,develop
-          VERSION_FILE_PATH: settings.gradle
-          VERSION_LINE_MATCH: "^gradle.ext.version\\s*=\\s*\".*\""
-          VERSION_SUFFIX: SNAPSHOT
+#      - name: "Bump the tag to a new version"
+#        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+#          DEFAULT_BUMP: patch
+#          RELEASE_BRANCHES: master,develop
+#          VERSION_FILE_PATH: settings.gradle
+#          VERSION_LINE_MATCH: "^gradle.ext.version\\s*=\\s*\".*\""
+#          VERSION_SUFFIX: SNAPSHOT
       - name: "Set up JDK"
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -17,33 +17,33 @@ jobs:
   development-tag-publish:
     runs-on: ubuntu-latest
     steps:
-#      - name: Set part of semantic version to bump
-#        id: semver
-#        run: |
-#          SEMVER_PART=""
-#          CHECKOUT_BRANCH="$GITHUB_REF"
-#          if ${{github.event_name == 'push' }}; then
-#            SEMVER_PART="patch"
-#          elif ${{github.event_name == 'workflow_dispatch' }}; then
-#            SEMVER_PART=${{ github.event.inputs.bump }}
-#            CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
-#          fi
-#          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
-#          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
+      - name: Set part of semantic version to bump
+        id: semver
+        run: |
+          SEMVER_PART=""
+          CHECKOUT_BRANCH="$GITHUB_REF"
+          if ${{github.event_name == 'push' }}; then
+            SEMVER_PART="patch"
+          elif ${{github.event_name == 'workflow_dispatch' }}; then
+            SEMVER_PART=${{ github.event.inputs.bump }}
+            CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
+          fi
+          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
+          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
           token: ${{ secrets.BROADBOT_TOKEN }}
-#      - name: "Bump the tag to a new version"
-#        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-#          DEFAULT_BUMP: patch
-#          RELEASE_BRANCHES: master,develop
-#          VERSION_FILE_PATH: settings.gradle
-#          VERSION_LINE_MATCH: "^gradle.ext.version\\s*=\\s*\".*\""
-#          VERSION_SUFFIX: SNAPSHOT
+      - name: "Bump the tag to a new version"
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          DEFAULT_BUMP: patch
+          RELEASE_BRANCHES: master,develop
+          VERSION_FILE_PATH: settings.gradle
+          VERSION_LINE_MATCH: "^gradle.ext.version\\s*=\\s*\".*\""
+          VERSION_SUFFIX: SNAPSHOT
       - name: "Set up JDK"
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/bumpDevelop.yaml
+++ b/.github/workflows/bumpDevelop.yaml
@@ -44,11 +44,14 @@ jobs:
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^gradle.ext.version\\s*=\\s*\".*\""
           VERSION_SUFFIX: SNAPSHOT
-      - name: "Publish to Artifactory"
-        uses: broadinstitute/gradle-command-action@v1
+      - name: "Set up JDK"
+        uses: actions/setup-java@v4
         with:
-          arguments: "artifactoryPublish"
+          java-version: '17'
+          distribution: 'temurin'
+      - name: "Publish to Artifactory"
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+        run: ./gradlew artifactoryPublish --scan

--- a/.github/workflows/bumpMaster.yaml
+++ b/.github/workflows/bumpMaster.yaml
@@ -42,11 +42,14 @@ jobs:
           RELEASE_BRANCHES: master,develop
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^gradle.ext.version\\s*=\\s*\".*\""
-      - name: "Publish to Artifactory"
-        uses: broadinstitute/gradle-command-action@v1
+      - name: "Set up JDK"
+        uses: actions/setup-java@v4
         with:
-          arguments: "artifactoryPublish"
+          java-version: '17'
+          distribution: 'temurin'
+      - name: "Publish to Artifactory"
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_REPO_KEY: "libs-release-local"
+        run: ./gradlew artifactoryPublish --scan


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-7

Stairway [failed to publish to Artifactory](https://github.com/DataBiosphere/stairway/actions/runs/8560392963/job/23459262781) following my merge of https://github.com/DataBiosphere/stairway/pull/139.

I was surprised, because I was able to run a dry run of this command locally without issues.

Turns out that we need to update our GHAs to set JDK 17 (we already do this in the build and test workload).

Verified: https://github.com/DataBiosphere/stairway/actions/runs/8560933780