### PR TITLE
PF-2987: minor patch dependencies

### DIFF
--- a/stairctl/build.gradle
+++ b/stairctl/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'application'
     id 'stairway.java-conventions'
 
-    id 'io.spring.dependency-management' version '1.1.4'
-    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.springframework.boot' version '3.3.0'
 }
 
 version = gradle.version
@@ -19,5 +19,5 @@ dependencies {
 
     // Spring
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter'
-    implementation group: 'org.springframework.shell', name: 'spring-shell-starter', version: '3.2.4'
+    implementation group: 'org.springframework.shell', name: 'spring-shell-starter', version: '3.2.5'
 }

--- a/stairctl/build.gradle
+++ b/stairctl/build.gradle
@@ -3,7 +3,8 @@ plugins {
     id 'stairway.java-conventions'
 
     id 'io.spring.dependency-management' version '1.1.5'
-    id 'org.springframework.boot' version '3.3.0'
+    // Spring Boot and Spring Shell versions should stay in sync
+    id 'org.springframework.boot' version '3.2.5'
 }
 
 version = gradle.version
@@ -19,5 +20,6 @@ dependencies {
 
     // Spring
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter'
+    // Spring Boot and Spring Shell versions should stay in sync
     implementation group: 'org.springframework.shell', name: 'spring-shell-starter', version: '3.2.5'
 }

--- a/stairway-azure/build.gradle
+++ b/stairway-azure/build.gradle
@@ -8,13 +8,13 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
 
     //Azure service bus dependencies
-    implementation 'com.azure:azure-messaging-servicebus:7.16.0'
-    implementation 'com.azure:azure-identity:1.12.0'
+    implementation 'com.azure:azure-messaging-servicebus:7.17.0'
+    implementation 'com.azure:azure-identity:1.12.1'
     // Azure dependencies pull in out-of-date, vulnerable io.netty dependencies.
     // If they update them in a future release, this may be removed:
-    implementation platform('io.netty:netty-bom:4.1.109.Final')
+    implementation platform('io.netty:netty-bom:4.1.110.Final')
 
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
 }
 
 apply from: "$rootDir/gradle/test.gradle"

--- a/stairway-gcp/build.gradle
+++ b/stairway-gcp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
 
     // Google dependencies
-    implementation platform('com.google.cloud:libraries-bom:26.38.0') // use common bom
+    implementation platform('com.google.cloud:libraries-bom:26.40.0') // use common bom
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
 }
 

--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 
     // JSON processing
-    implementation platform('com.fasterxml.jackson:jackson-bom:2.17.0')
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.17.1')
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
@@ -18,16 +18,16 @@ dependencies {
     implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
 
     // Spring
-    implementation group: 'org.springframework', name: 'spring-web', version: '6.1.6'
+    implementation group: 'org.springframework', name: 'spring-web', version: '6.1.8'
 
     // Annotations
     implementation group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '3.0.0'
 
     // Database
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.27.0'
+    implementation group: 'org.liquibase', name: 'liquibase-core', version: '4.28.0'
 
     // Google dependencies
-    implementation platform('com.google.cloud:libraries-bom:26.38.0') // use common bom
+    implementation platform('com.google.cloud:libraries-bom:26.40.0') // use common bom
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
 
     // File handling during testing


### PR DESCRIPTION
supersedes Dependabot's #147, which has build failures.

The Spring Boot and Spring Shell versions should stay in sync, but that other PR uses divergent versions and that is the cause of the build failures.

This PR is branched from that other PR but has an extra commit 5d887bed7512831b07b4641eec3bccb7eb36a50d that fixes the Boot/Shell versions.

NOTE: Dependabot could very well try to upgrade Spring Boot again in its next pass; I am not trying to prevent that in this PR.