### PR TITLE
[DCJ-457] Stairway can be built with a provided ThreadPoolTaskExecutor

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,12 +54,15 @@ Gradle makes this easy with a `mavenLocal` target for publishing and loading pac
 
    ```
    # terra-workspace-manager/build.gradle
-   
+
+   // If true, search local repository (~/.m2/repository/) first for dependencies.
+   def useMavenLocal = true
    repositories {
-     mavenLocal()
-     mavenCentral()
-     ...
-   }
+      if (useMavenLocal) {
+          mavenLocal() // must be listed first to take effect
+      }
+      mavenCentral()
+      ...
    ```
 
 That's it! Your service should pick up locally-published changes. If your changes involved bumping

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,6 +35,36 @@ match the values in the sql file above:
 For folks working on Terra, the Stairway configuration is embedded within the component
 configuration, so these steps are included in component developer setup.
 
+## Local Publishing
+When working on this library, it is often helpful to be able to quickly test out changes
+in the context of a service repo (e.g. `terra-workspace-manager` or `terra-resource-buffer`)
+running a local server.
+
+Gradle makes this easy with a `mavenLocal` target for publishing and loading packages:
+
+1. Publish from Stairway to your machine's local Maven cache.
+
+   ```
+   ./gradlew publishToMavenLocal
+   ```
+
+   Your package will be in `~/.m2/repository`.
+2. From the service repo, add `mavenLocal()` to the _first_ repository location
+   build.gradle file (e.g. before `mavenCentral()`).
+
+   ```
+   # terra-workspace-manager/build.gradle
+   
+   repositories {
+     mavenLocal()
+     mavenCentral()
+     ...
+   }
+   ```
+
+That's it! Your service should pick up locally-published changes. If your changes involved bumping
+this library's version, be careful to update version numbers accordingly.
+
 ## SourceClear
 
 [SourceClear](https://srcclr.github.io) is a static analysis tool that scans a project's Java

--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
 
     // Spring
+    implementation group: 'org.springframework', name: 'spring-context', version: '6.1.8'
     implementation group: 'org.springframework', name: 'spring-web', version: '6.1.8'
 
     // Annotations

--- a/stairway/src/main/java/bio/terra/stairway/DefaultThreadPoolTaskExecutor.java
+++ b/stairway/src/main/java/bio/terra/stairway/DefaultThreadPoolTaskExecutor.java
@@ -1,0 +1,31 @@
+package bio.terra.stairway;
+
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+public class DefaultThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
+
+  static final int DEFAULT_MAX_PARALLEL_FLIGHTS = 20;
+
+  /**
+   * An initialized {@link ThreadPoolTaskExecutor}.
+   *
+   * @param maxParallelFlights the desired pool size, honored if a positive integer, defaults to
+   *     DEFAULT_MAX_PARALLEL_FLIGHTS otherwise.
+   */
+  public DefaultThreadPoolTaskExecutor(Integer maxParallelFlights) {
+    super();
+    int poolSize = getPoolSize(maxParallelFlights);
+    super.setCorePoolSize(poolSize);
+    super.setMaxPoolSize(poolSize);
+    super.setKeepAliveSeconds(0);
+    super.setThreadNamePrefix("stairway-thread-");
+    super.initialize();
+  }
+
+  private int getPoolSize(Integer maxParallelFlights) {
+    if (maxParallelFlights == null || maxParallelFlights <= 0) {
+      return DEFAULT_MAX_PARALLEL_FLIGHTS;
+    }
+    return maxParallelFlights;
+  }
+}

--- a/stairway/src/main/java/bio/terra/stairway/StairwayBuilder.java
+++ b/stairway/src/main/java/bio/terra/stairway/StairwayBuilder.java
@@ -31,8 +31,8 @@ public class StairwayBuilder {
   private Duration completedFlightRetention;
 
   /**
-   * Determines the size of the thread pool used for running Stairway flights. Default is
-   * established in {@link DefaultThreadPoolTaskExecutor} (20 at this moment).
+   * Determines the size of the thread pool used for running Stairway flights. Default is {@value
+   * DefaultThreadPoolTaskExecutor#DEFAULT_MAX_PARALLEL_FLIGHTS}.
    *
    * @param maxParallelFlights maximum parallel flights to run
    * @return this

--- a/stairway/src/main/java/bio/terra/stairway/StairwayBuilder.java
+++ b/stairway/src/main/java/bio/terra/stairway/StairwayBuilder.java
@@ -5,6 +5,7 @@ import bio.terra.stairway.impl.StairwayImpl;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /**
  * This builder class is the way to constructing a Stairway instance. For example,
@@ -21,6 +22,7 @@ public class StairwayBuilder {
   private final List<StairwayHook> stairwayHooks = new ArrayList<>();
   private Integer maxParallelFlights;
   private Integer maxQueuedFlights;
+  private ThreadPoolTaskExecutor executor;
   private Object applicationContext;
   private ExceptionSerializer exceptionSerializer;
   private String stairwayName;
@@ -30,7 +32,7 @@ public class StairwayBuilder {
 
   /**
    * Determines the size of the thread pool used for running Stairway flights. Default is
-   * DEFAULT_MAX_PARALLEL_FLIGHTS (20 at this moment)
+   * established in {@link DefaultThreadPoolTaskExecutor} (20 at this moment).
    *
    * @param maxParallelFlights maximum parallel flights to run
    * @return this
@@ -64,6 +66,24 @@ public class StairwayBuilder {
 
   public Integer getMaxQueuedFlights() {
     return maxQueuedFlights;
+  }
+
+  /**
+   * Allow a caller to provide their own {@link ThreadPoolTaskExecutor} to use as this Stairway's
+   * threadpool, e.g. as to supply an instrumented executor with custom metrics collection. Default
+   * is a new instance of {@link DefaultThreadPoolTaskExecutor}.
+   *
+   * @param executor to use as this Stairway's threadpool. If not supplied, one will be constructed
+   *     to honor maxParallelFlights.
+   * @return this
+   */
+  public StairwayBuilder executor(ThreadPoolTaskExecutor executor) {
+    this.executor = executor;
+    return this;
+  }
+
+  public ThreadPoolTaskExecutor getExecutor() {
+    return executor;
   }
 
   /**

--- a/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
@@ -103,8 +103,9 @@ public class StairwayImpl implements Stairway {
             : builder.getStairwayName();
 
     this.executor =
-        Optional.ofNullable(builder.getExecutor())
-            .orElse(new DefaultThreadPoolTaskExecutor(builder.getMaxParallelFlights()));
+        (builder.getExecutor() == null)
+            ? new DefaultThreadPoolTaskExecutor(builder.getMaxParallelFlights())
+            : builder.getExecutor();
 
     this.queueManager = new WorkQueueManager(this, builder.getWorkQueue());
 

--- a/stairway/src/test/java/bio/terra/stairway/DefaultThreadPoolTaskExecutorTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/DefaultThreadPoolTaskExecutorTest.java
@@ -2,6 +2,7 @@ package bio.terra.stairway;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
@@ -29,5 +30,6 @@ class DefaultThreadPoolTaskExecutorTest {
     assertThat(executor.getMaxPoolSize(), equalTo(expectedPoolSize));
     assertThat(executor.getKeepAliveSeconds(), equalTo(0));
     assertThat(executor.getThreadNamePrefix(), equalTo("stairway-thread-"));
+    assertTrue(executor.isRunning());
   }
 }

--- a/stairway/src/test/java/bio/terra/stairway/DefaultThreadPoolTaskExecutorTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/DefaultThreadPoolTaskExecutorTest.java
@@ -1,0 +1,33 @@
+package bio.terra.stairway;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("unit")
+class DefaultThreadPoolTaskExecutorTest {
+
+  private static Stream<Arguments> defaultThreadPoolTaskExecutor() {
+    return Stream.of(
+        Arguments.of(null, DefaultThreadPoolTaskExecutor.DEFAULT_MAX_PARALLEL_FLIGHTS),
+        Arguments.of(-1, DefaultThreadPoolTaskExecutor.DEFAULT_MAX_PARALLEL_FLIGHTS),
+        Arguments.of(0, DefaultThreadPoolTaskExecutor.DEFAULT_MAX_PARALLEL_FLIGHTS),
+        Arguments.of(1, 1),
+        Arguments.of(50, 50));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void defaultThreadPoolTaskExecutor(Integer maxParallelFlights, Integer expectedPoolSize) {
+    var executor = new DefaultThreadPoolTaskExecutor(maxParallelFlights);
+    assertThat(executor.getCorePoolSize(), equalTo(expectedPoolSize));
+    assertThat(executor.getMaxPoolSize(), equalTo(expectedPoolSize));
+    assertThat(executor.getKeepAliveSeconds(), equalTo(0));
+    assertThat(executor.getThreadNamePrefix(), equalTo("stairway-thread-"));
+  }
+}

--- a/stairway/src/test/java/bio/terra/stairway/impl/StairwayThreadPoolTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/StairwayThreadPoolTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import bio.terra.stairway.DefaultThreadPoolTaskExecutor;
 import bio.terra.stairway.fixtures.TestFlightContext;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +35,8 @@ class StairwayThreadPoolTest {
   @BeforeEach
   void beforeEach() {
     MDC.clear();
-    stairwayThreadPool = new StairwayThreadPool(MAX_PARALLEL_FLIGHTS);
+    stairwayThreadPool =
+        new StairwayThreadPool(new DefaultThreadPoolTaskExecutor(MAX_PARALLEL_FLIGHTS));
     flightContext = new TestFlightContext().flightId(FLIGHT_ID).flightClassName(FLIGHT_CLASS);
   }
 


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-457

PRs will need to be merged in the following order:
1. This PR
2. https://github.com/DataBiosphere/terra-common-lib/pull/187
3. A forthcoming TDR PR to update its TCL version

## Summary of changes

This PR allows calling services to bring their own instrumented executor to serve as their Stairway's threadpool.

If unspecified in `StairwayBuilder`, a `DefaultThreadPoolTaskExecutor` will be constructed and used.

`DefaultThreadPoolTaskExecutor` is a public class: calling services may elect to instantiate it themselves (e.g. a Spring Boot service would register this as a Bean for automatic actuator instrumentation).

## Testing Strategy

Expanded unit tests.

Verified end-to-end behavior manually:
- Publishing Stairway and TCL to my local Maven repository
- Booting up TDR, with and without `maxParallelFlights` specified
- Observed that `stairwayExecutor` metrics were automatically flowing through TDR's Actuator endpoint
- Initiated a Stairway flight which succeeded.  Executor occupancy was reflected in actuator metrics.

Example where TDR configured its `maxParallelFlights` to be 120, has one actively running flight, and one completed flight:
```
(base) okotsopo@wm111-e35 jade-data-repo % curl http://localhost:8080/actuator/prometheus | grep 'stairwayExecutor'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 87022  100 8executor_pool_core_threads{name="stairwayExecutor",} 120.0   0
7022    0     0  10.1M      0 --:--:-- --:--:-- --:--:-- 10.3M
executor_queue_remaining_tasks{name="stairwayExecutor",} 2.147483647E9
executor_completed_tasks_total{name="stairwayExecutor",} 1.0
executor_pool_size_threads{name="stairwayExecutor",} 2.0
executor_queued_tasks{name="stairwayExecutor",} 0.0
executor_pool_max_threads{name="stairwayExecutor",} 120.0
executor_active_threads{name="stairwayExecutor",} 1.0
```