### PR TITLE
[DCJ-507] Stairway with work queue enabled should be context-aware

### DIFF
--- a/stairway/build.gradle
+++ b/stairway/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 
     // File handling during testing
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.16.1'
+
+    // Mocks during testing
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.12.0'
 }
 
 apply from: "$rootDir/gradle/test.gradle"

--- a/stairway/src/main/java/bio/terra/stairway/impl/MdcUtils.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/MdcUtils.java
@@ -39,7 +39,6 @@ public class MdcUtils {
     Map<String, String> initialContext = MDC.getCopyOfContextMap();
     try {
       MdcUtils.overwriteContext(context);
-      System.out.println(MDC.getCopyOfContextMap());
       return callable.call();
     } catch (InterruptedException ex) {
       throw ex;

--- a/stairway/src/main/java/bio/terra/stairway/impl/MdcUtils.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/MdcUtils.java
@@ -1,7 +1,9 @@
 package bio.terra.stairway.impl;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.exception.StairwayExecutionException;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import org.slf4j.MDC;
 
 /**
@@ -9,7 +11,6 @@ import org.slf4j.MDC;
  * (MDC).
  */
 public class MdcUtils {
-
   /** ID of the flight */
   static final String FLIGHT_ID_KEY = "flightId";
 
@@ -26,11 +27,35 @@ public class MdcUtils {
   static final String FLIGHT_STEP_NUMBER_KEY = "flightStepNumber";
 
   /**
+   * Run and return the result of the callable with MDC's context map temporarily overwritten during
+   * computation. The initial context map is then restored after computation.
+   *
+   * @param context to override MDC's context map
+   * @param callable to call and return
+   */
+  public static <T> T callWithContext(Map<String, String> context, Callable<T> callable)
+      throws InterruptedException {
+    // Save the initial thread context so that it can be restored
+    Map<String, String> initialContext = MDC.getCopyOfContextMap();
+    try {
+      MdcUtils.overwriteContext(context);
+      System.out.println(MDC.getCopyOfContextMap());
+      return callable.call();
+    } catch (InterruptedException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new StairwayExecutionException("Unexpected exception " + ex.getMessage(), ex);
+    } finally {
+      MdcUtils.overwriteContext(initialContext);
+    }
+  }
+
+  /**
    * Null-safe utility method for overwriting the current thread's MDC.
    *
    * @param context to set as MDC, if null then MDC will be cleared.
    */
-  public static void overwriteContext(Map<String, String> context) {
+  static void overwriteContext(Map<String, String> context) {
     MDC.clear();
     if (context != null) {
       MDC.setContextMap(context);

--- a/stairway/src/main/java/bio/terra/stairway/impl/MdcUtils.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/MdcUtils.java
@@ -8,7 +8,7 @@ import org.slf4j.MDC;
  * Utility methods to make Stairway flight runnables context-aware, using mapped diagnostic context
  * (MDC).
  */
-class MdcUtils {
+public class MdcUtils {
 
   /** ID of the flight */
   static final String FLIGHT_ID_KEY = "flightId";
@@ -30,7 +30,7 @@ class MdcUtils {
    *
    * @param context to set as MDC, if null then MDC will be cleared.
    */
-  static void overwriteContext(Map<String, String> context) {
+  public static void overwriteContext(Map<String, String> context) {
     MDC.clear();
     if (context != null) {
       MDC.setContextMap(context);

--- a/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
+++ b/stairway/src/main/java/bio/terra/stairway/impl/StairwayImpl.java
@@ -26,7 +26,6 @@ import bio.terra.stairway.queue.WorkQueueManager;
 import jakarta.annotation.Nullable;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;

--- a/stairway/src/test/java/bio/terra/stairway/impl/MdcUtilsTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/impl/MdcUtilsTest.java
@@ -2,21 +2,27 @@ package bio.terra.stairway.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.stairway.Direction;
+import bio.terra.stairway.exception.StairwayExecutionException;
 import bio.terra.stairway.fixtures.TestFlightContext;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.MDC;
 
 @Tag("unit")
 class MdcUtilsTest {
+  private static final Map<String, String> INITIAL_CONTEXT = Map.of("initial", "context");
   private static final Map<String, String> FOO_BAR = Map.of("foo", "bar");
   private static final String FLIGHT_ID = "flightId" + UUID.randomUUID();
   private static final String FLIGHT_CLASS = "flightClass" + UUID.randomUUID();
@@ -50,6 +56,57 @@ class MdcUtilsTest {
 
   static Stream<Map<String, String>> contextMap() {
     return Stream.of(null, Map.of(), FOO_BAR);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextMap")
+  void callWithContext(Map<String, String> newContext) throws InterruptedException {
+    MDC.setContextMap(INITIAL_CONTEXT);
+    Boolean result =
+        MdcUtils.callWithContext(
+            newContext,
+            () -> {
+              assertThat(
+                  "Context is overwritten during computation",
+                  MDC.getCopyOfContextMap(),
+                  equalTo(newContext));
+              return true;
+            });
+    assertThat("Result of computation is returned", result, equalTo(true));
+    assertThat("Initial context is restored", MDC.getCopyOfContextMap(), equalTo(INITIAL_CONTEXT));
+  }
+
+  static Stream<Arguments> callWithContext_exception() {
+    List<Arguments> arguments = new ArrayList<>();
+    for (var newContext : contextMap().toList()) {
+      arguments.add(
+          Arguments.of(
+              newContext, new InterruptedException("interrupted"), InterruptedException.class));
+      arguments.add(
+          Arguments.of(
+              newContext, new RuntimeException("unexpected"), StairwayExecutionException.class));
+    }
+    return arguments.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  <T extends Throwable> void callWithContext_exception(
+      Map<String, String> newContext, Exception exception, Class<T> expectedExceptionClass) {
+    MDC.setContextMap(INITIAL_CONTEXT);
+    assertThrows(
+        expectedExceptionClass,
+        () ->
+            MdcUtils.callWithContext(
+                newContext,
+                () -> {
+                  assertThat(
+                      "Context is overwritten during computation",
+                      MDC.getCopyOfContextMap(),
+                      equalTo(newContext));
+                  throw exception;
+                }));
+    assertThat("Initial context is restored", MDC.getCopyOfContextMap(), equalTo(INITIAL_CONTEXT));
   }
 
   @ParameterizedTest

--- a/stairway/src/test/java/bio/terra/stairway/queue/QueueMessageTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/queue/QueueMessageTest.java
@@ -25,7 +25,7 @@ import org.slf4j.MDC;
 
 @Tag("unit")
 @ExtendWith(MockitoExtension.class)
-public class QueueMessageTest {
+class QueueMessageTest {
 
   @Mock private StairwayImpl stairway;
   private static final String FLIGHT_ID = "flight-abc";
@@ -43,7 +43,7 @@ public class QueueMessageTest {
 
   @ParameterizedTest
   @MethodSource
-  public void message_serde(Map<String, String> expectedMdc) {
+  void message_serde(Map<String, String> expectedMdc) {
     MdcUtils.overwriteContext(expectedMdc);
     QueueMessageReady messageReady = new QueueMessageReady(FLIGHT_ID);
     WorkQueueProcessor workQueueProcessor = new WorkQueueProcessor(stairway);
@@ -68,7 +68,7 @@ public class QueueMessageTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void process(boolean resumeAnswer) throws InterruptedException {
+  void process(boolean resumeAnswer) throws InterruptedException {
     QueueMessageReady messageReady = new QueueMessageReady(FLIGHT_ID);
     messageReady.setCallingThreadContext(CALLING_THREAD_CONTEXT);
 
@@ -91,7 +91,7 @@ public class QueueMessageTest {
   }
 
   @Test
-  public void process_DatabaseOperationException() throws InterruptedException {
+  void process_DatabaseOperationException() throws InterruptedException {
     QueueMessageReady messageReady = new QueueMessageReady(FLIGHT_ID);
     messageReady.setCallingThreadContext(CALLING_THREAD_CONTEXT);
 

--- a/stairway/src/test/java/bio/terra/stairway/queue/QueueMessageTest.java
+++ b/stairway/src/test/java/bio/terra/stairway/queue/QueueMessageTest.java
@@ -1,32 +1,106 @@
 package bio.terra.stairway.queue;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
+import bio.terra.stairway.exception.DatabaseOperationException;
+import bio.terra.stairway.impl.MdcUtils;
+import bio.terra.stairway.impl.StairwayImpl;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.slf4j.MDC;
 
 @Tag("unit")
+@ExtendWith(MockitoExtension.class)
 public class QueueMessageTest {
 
+  @Mock private StairwayImpl stairway;
+  private static final String FLIGHT_ID = "flight-abc";
+  private static final Map<String, String> CALLING_THREAD_CONTEXT =
+      Map.of("requestId", "request-abc");
+
+  @BeforeEach
+  void beforeEach() {
+    MDC.clear();
+  }
+
+  private static Stream<Map<String, String>> message_serde() {
+    return Stream.of(null, CALLING_THREAD_CONTEXT);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void message_serde(Map<String, String> expectedMdc) {
+    MdcUtils.overwriteContext(expectedMdc);
+    QueueMessageReady messageReady = new QueueMessageReady(FLIGHT_ID);
+    WorkQueueProcessor workQueueProcessor = new WorkQueueProcessor(stairway);
+
+    // Now we add something else to the MDC, but it won't show up in our deserialized queue message.
+    MDC.put("another-key", "another-value");
+
+    String serialized = workQueueProcessor.serialize(messageReady);
+    QueueMessage deserialized = workQueueProcessor.deserialize(serialized);
+    assertThat(deserialized, instanceOf(QueueMessageReady.class));
+
+    QueueMessageReady messageReadyCopy = (QueueMessageReady) deserialized;
+    assertThat(messageReadyCopy.getFlightId(), equalTo(messageReady.getFlightId()));
+    assertThat(
+        messageReadyCopy.getType().getMessageEnum(),
+        equalTo(messageReady.getType().getMessageEnum()));
+    assertThat(
+        messageReadyCopy.getType().getVersion(), equalTo(messageReady.getType().getVersion()));
+    assertThat(messageReadyCopy.getFlightId(), equalTo(messageReady.getFlightId()));
+    assertThat(messageReadyCopy.getCallingThreadContext(), equalTo(expectedMdc));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void process(boolean resumeAnswer) throws InterruptedException {
+    QueueMessageReady messageReady = new QueueMessageReady(FLIGHT_ID);
+    messageReady.setCallingThreadContext(CALLING_THREAD_CONTEXT);
+
+    when(stairway.resume(FLIGHT_ID))
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  assertThat(
+                      "MDC is set during processing",
+                      MDC.getCopyOfContextMap(),
+                      equalTo(CALLING_THREAD_CONTEXT));
+                  return resumeAnswer;
+                });
+
+    assertThat(
+        "Message is considered processed when stairway.resume returns " + resumeAnswer,
+        messageReady.process(stairway),
+        equalTo(true));
+    assertThat("MDC is reverted after processing", MDC.getCopyOfContextMap(), equalTo(null));
+  }
+
   @Test
-  public void messageTest() throws Exception {
-    WorkQueueProcessor queueProcessor = new WorkQueueProcessor(null);
-    QueueMessageReady messageReady = new QueueMessageReady("abcde");
-    String serialized = queueProcessor.serialize(messageReady);
-    QueueMessage deserialized = queueProcessor.deserialize(serialized);
-    if (deserialized instanceof QueueMessageReady) {
-      QueueMessageReady messageReadyCopy = (QueueMessageReady) deserialized;
-      assertThat(messageReadyCopy.getFlightId(), equalTo(messageReady.getFlightId()));
-      assertThat(
-          messageReadyCopy.getType().getMessageEnum(),
-          equalTo(messageReady.getType().getMessageEnum()));
-      assertThat(
-          messageReadyCopy.getType().getVersion(), equalTo(messageReady.getType().getVersion()));
-      assertThat(messageReadyCopy.getFlightId(), equalTo(messageReady.getFlightId()));
-    } else {
-      fail();
-    }
+  public void process_DatabaseOperationException() throws InterruptedException {
+    QueueMessageReady messageReady = new QueueMessageReady(FLIGHT_ID);
+    messageReady.setCallingThreadContext(CALLING_THREAD_CONTEXT);
+
+    doThrow(DatabaseOperationException.class).when(stairway).resume(FLIGHT_ID);
+
+    assertThat(
+        "Message is left on the queue when stairway.resume throws",
+        messageReady.process(stairway),
+        equalTo(false));
+    assertThat(MDC.getCopyOfContextMap(), equalTo(null));
   }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-507

## Addresses

Context-aware Stairway previously assumed that the calling thread would have mapped diagnostic context (MDC) to persist to the child threads spawned for flight execution.

This was not the case when Stairway is configured with a work queue enabled (e.g. GCP Pub-Sub).  Here, flight information was written to the pub-sub topic without the calling thread's context, so when a message was processed and deserialized any logs emitted from that flight would be missing context set by the original calling thread (e.g. request ID).

Where we've felt this impact in TDR:
- Child flights submitted within the execution of a parent flight are missing the calling thread's context in its logs.
- While this is an uncommon pattern for flight execution, it is used when facilitating combined data ingests to datasets: the parent flight ingests tabular data, and child flights are spawned for each file being ingested.
- Much of our attention has been on debugging combined data ingests to Azure datasets: the inability to filter for all connected parent and child flight logs in GCP log console by request ID (`jsonPayload.requestId`) is slowing down investigative progress. 

## Summary of changes

- Added new helper method `MdcUtils.callWithContext` to call a callable and return its result with MDC's context map temporarily overwritten.
- Expanded `QueueMessageReady` to store calling thread context on construction.
- `QueueMessageReady.process()` sets the MDC using its stored calling thread context, which then makes the flight context-aware.

## Testing Strategy

- Added unit tests for `MdcUtils.callWithContext`.
- Expanded unit tests for `QueueMessageReady` with special attention to MDC behavior and propagation in serialization, deserialization, and processing.

~~Note: Sonarcloud coverage stats are incorrectly reporting 0% coverage.  They look to have never worked.  I do believe I've covered all of my changes in unit tests.~~ ETA: thanks @pshapiro4broad for fixing the Sonar scans, I pulled the fix into this branch and we are now seeing coverage stats.