### PR TITLE
PF-3003: Add code coverage to sonar report

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -37,11 +37,11 @@ jobs:
           --health-retries 5
         ports: [ "5432:5432" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: Run tests
-        run: ./gradlew test --scan
+        run: ./gradlew test --scan jacocoTestReport
 
       # Run the Sonar scan after `gradle test` to include code coverage data in its report.
       - name: Sonar scan

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_stairway&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_stairway)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_stairway&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_stairway)
+
 # Stairway
 Stairway is a library that provides a framework for running _saga transactions_. Saga
 transactions, introduced by Hector Garcia-Molina in 1987, use _compensating operations_ to

--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,9 @@ sonar {
         property "sonar.projectKey", "DataBiosphere_stairway"
         property "sonar.organization", "broad-databiosphere"
         property "sonar.host.url", "https://sonarcloud.io"
+        property 'sonar.coverage.jacoco.xmlReportPaths',
+                "$rootDir/stairway/build/reports/jacoco/test/jacocoTestReport.xml," +
+                "$rootDir/stairway-gcp/build/reports/jacoco/test/jacocoTestReport.xml," +
+                "$rootDir/stairway-azure/build/reports/jacoco/test/jacocoTestReport.xml"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,5 @@ sonar {
         property "sonar.projectKey", "DataBiosphere_stairway"
         property "sonar.organization", "broad-databiosphere"
         property "sonar.host.url", "https://sonarcloud.io"
-        property 'sonar.coverage.jacoco.xmlReportPaths',
-                "$rootDir/stairway/build/reports/jacoco/test/jacocoTestReport.xml," +
-                "$rootDir/stairway-gcp/build/reports/jacoco/test/jacocoTestReport.xml," +
-                "$rootDir/stairway-azure/build/reports/jacoco/test/jacocoTestReport.xml"
     }
 }

--- a/buildSrc/src/main/groovy/stairway.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/stairway.java-conventions.gradle
@@ -1,6 +1,7 @@
 // Java conventions common for all of the code
 plugins {
     id 'idea'
+    id 'jacoco'
     id 'java'
     id 'java-library'
     id 'com.diffplug.spotless'
@@ -52,5 +53,12 @@ if (hasProperty("buildScan")) {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
+    }
+}
+
+jacocoTestReport {
+    reports {
+        // sonar requires XML coverage output to upload coverage data
+        xml.required = true
     }
 }


### PR DESCRIPTION
Generate and push code coverage results to the repo's sonar scan.

Sonar support was added in https://github.com/DataBiosphere/stairway/pull/126, but since the build wasn't generating coverage data there wasn't any coverage in the sonar scan.

I generated a sonar coverage report by running locally, at PR creation time the results are here: https://sonarcloud.io/component_measures?id=DataBiosphere_stairway&metric=coverage&view=list

Note that overall coverage is only 66%, but that number is skewed by the `stairctl` subproject which has no unit tests.

Also note, the coverage report for this PR will be empty since sonar only shows coverage for files included in the current commit, and no java code files were changed in this PR.