### PR TITLE
skipJreProvisioning for Sonar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,6 @@ sonar {
         property "sonar.projectKey", "DataBiosphere_stairway"
         property "sonar.organization", "broad-databiosphere"
         property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.scanner.skipJreProvisioning", "true"
     }
 }


### PR DESCRIPTION
Configure the Sonar scanner to use the pre-existing Java installation instead of provisioning its own.

This change appears to resolve an execution problem in #170. See #173, which is a copy of #170 but with this flag enabled.

I hope to get this PR approved and merged, then ask Dependabot to rebase #170, then merge #170.