### PR TITLE
[DT-2238] Update CODEOWNERS to jadeteam

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
+*       @DataBiosphere/jadeteam
 *       @DataBiosphere/dsp-data-team-eng


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-2238

## Summary of changes

Switches the [`jadeteam`](https://github.com/orgs/DataBiosphere/teams/jadeteam) to be the primary CODEOWNERS of the repository.
