### PR TITLE
[DSEC-995] bump sonarqube version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'idea'
 
     id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.1.5'
-    id "org.sonarqube" version "7.2.2.6593"
+    id "org.sonarqube" version "7.2.3.7755"
 }
 
 // task dependencies is NOT recursively executed on subprojects


### PR DESCRIPTION
SonarQube is fixed now, mainly because I fixed the token. The version bump wasn't needed to fix the problem.

Also see https://github.com/broadinstitute/terraform-ap-deployments/pull/2034 to terraform the secret from gsm (but I manually set the secret to test this).